### PR TITLE
Update runlib

### DIFF
--- a/data_from_portwine/scripts/runlib
+++ b/data_from_portwine/scripts/runlib
@@ -479,7 +479,7 @@ START_PORTWINE () {
         killall xneur
         export int_xneur=1
     fi
-    export PW_XKBD="$(setxkbmap -query | grep -w ru | awk '{print($2)}')"
+    export PW_XKBD="$(setxkbmap -query | grep -Ew "(us|uk)" | awk '{print($2)}')"
     if [ ! -z ${PW_XKBD} ]; then
         setxkbmap us,ru
     fi


### PR DESCRIPTION
Изменил  PW_XKBD на  export PW_XKBD="$(setxkbmap -query | grep -Ew "(us|uk)" | awk '{print($2)}')"
Грепает раскладку не по Русскому, а по Английскому языку. 
Теперь должно нормально работать на системах не имеющих русской раскладки.