### PR TITLE
Use ENG locale if missing lang

### DIFF
--- a/data_from_portwine/scripts/lang
+++ b/data_from_portwine/scripts/lang
@@ -2,6 +2,7 @@
 # Author: linux-gaming.ru
 
 read "update_loc" < "${PORT_WINE_TMP_PATH}/${portname}_loc"
+[ -z "${update_loc}" ] && update_loc="ENG"
 export update_loc=${update_loc}
 
 if [ "${update_loc}" = "RUS" ]

--- a/data_from_portwine/scripts/lang
+++ b/data_from_portwine/scripts/lang
@@ -2,7 +2,6 @@
 # Author: linux-gaming.ru
 
 read "update_loc" < "${PORT_WINE_TMP_PATH}/${portname}_loc"
-[ -z "${update_loc}" ] && update_loc="ENG"
 export update_loc=${update_loc}
 
 if [ "${update_loc}" = "RUS" ]
@@ -210,8 +209,7 @@ then
 	export loc_gui_installing_the="Устанавливаем"
 	export loc_gui_please_wait="Пожалуйста подождите..."
 
-elif [ "${update_loc}" = "ENG" ]
-then
+else
 	export loc_gui_installing_the="Installing the"
 	export loc_gui_please_wait="Please wait..."
 


### PR DESCRIPTION
После одного из обновлений затерся файл `tmp/PortProton_loc` и теперь вот такая красота
![изображение](https://user-images.githubusercontent.com/12619075/206256889-9140b520-c4a4-4d57-a97e-b8c0e9233a4a.png)

Можно решить удалением этого файла, но лучше наверное ставить дефолт чтобы в настройках не на ощупь искать кнопку переключения языка.