### PR TITLE
Fix run errors for nvidia hybrid setup

### DIFF
--- a/data_from_portwine/scripts/runlib
+++ b/data_from_portwine/scripts/runlib
@@ -194,8 +194,7 @@ start_portwine () {
         elif [ -x "`which prime-run 2>/dev/null`" ]; then
             export optirun_on="prime-run"
             check_nvidia_vk_icd_file
-        elif [[ -x "`which nvidia-settings 2>/dev/null`" ]] ; then 
-            export __GLX_VENDOR_LIBRARY_NAME=nvidia
+        elif [[ -x "`which nvidia-settings 2>/dev/null`" ]] ; then
             check_nvidia_vk_icd_file
         fi
     else


### PR DESCRIPTION
Issue exists very long time. This line produce error while running some 32 bit games on nvidia hybrid setup. Without this line it run all kind of games without any issues on discrete GPU. Tested on two different laptops on `manjaro` and `fedora`. So, I don't sure it's needed here at all.

The fixed error is:

```X Error of failed request:  BadValue (integer parameter out of range for operation)
Major opcode of failed request:  156 (NV-GLX)
Minor opcode of failed request:  6 ()
Value in failed request:  0x0
Serial number of failed request:  96
Current serial number in output stream:  96
```

Interesting thing that the same output can be reproduced by running `__GLX_VENDOR_LIBRARY_NAME=nvidia glxinfo`
Successful variant of command is: `__NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia glxinfo`

Also as I understand `__NV_PRIME_RENDER_OFFLOAD` and `__GLX_VENDOR_LIBRARY_NAME` should be together. So, I guess (but not sure) that `export __GLX_VENDOR_LIBRARY_NAME=nvidia` should be added after `export __NV_PRIME_RENDER_OFFLOAD=1` (line 155) if `PW_PRIME_RENDER_OFFLOAD` enabled.