### PR TITLE
Update PRIME Render Offload

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -808,12 +808,9 @@ nvidia_check_rtx () {
     return 1
 }
 
-# Hybrid graphics (Intel + NVIDIA)
-if echo "$lspci_output" | grep -i "intel" && echo "$lspci_output" | grep -i "nvidia"; then
-    export PW_PRIME_RENDER_OFFLOAD=1
-# Hybrid graphics (AMD + NVIDIA)
-elif echo "$lspci_output" | grep -i "amd" && echo "$lspci_output" | grep -i "nvidia"; then
-    export PW_PRIME_RENDER_OFFLOAD=1
+# Hybrid graphics detect
+if echo "$lspci_output" | grep -i "nvidia" && echo "$lspci_output" | grep -i "intel") || (echo "$lspci_output" | grep -i "nvidia" && echo "$lspci_output" | grep -i "amd"); then
+  export PW_PRIME_RENDER_OFFLOAD=1
 fi
 
 pw_init_db () {

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -791,8 +791,9 @@ pw_check_and_download_plugins () {
     return 0
 }
 
+lspci_output=$(lspci | grep VGA)
+
 nvidia_check_rtx () {
-    lspci_output=$(lspci | grep VGA)
     if echo "$lspci_output" | grep -i "nvidia" ; then          
         # Turing (without nvidia 16XX)
         nv_arch=$(echo "$lspci_output" | sed -rn 's/.*(TU[0-9]*).*/\1/p')
@@ -806,6 +807,14 @@ nvidia_check_rtx () {
     fi
     return 1
 }
+
+# Hybrid graphics (Intel + NVIDIA)
+if echo "$lspci_output" | grep -i "intel" && echo "$lspci_output" | grep -i "nvidia"; then
+    export PW_PRIME_RENDER_OFFLOAD=1
+# Hybrid graphics (AMD + NVIDIA)
+elif echo "$lspci_output" | grep -i "amd" && echo "$lspci_output" | grep -i "nvidia"; then
+    export PW_PRIME_RENDER_OFFLOAD=1
+fi
 
 pw_init_db () {
     if [[ ! -z "${portwine_exe}" ]] ; then

--- a/data_from_portwine/scripts/runlib
+++ b/data_from_portwine/scripts/runlib
@@ -171,6 +171,7 @@ start_portwine () {
 
     if [[ "${PW_PRIME_RENDER_OFFLOAD}" == 1 ]] ; then
         export __NV_PRIME_RENDER_OFFLOAD=1
+        export __VK_LAYER_NV_optimus=NVIDIA_only
         export __GLX_VENDOR_LIBRARY_NAME=nvidia
     fi
 


### PR DESCRIPTION
Added Finer-Grained Control of PRIME Render Offload on Vulkan applications 
Added automatic activation of PRIME Render Offload when hybrid graphics are detected
I described __VK_LAYER_NV_optimus=NVIDIA_only in a past pr that had to be closed because it started to conflict with the main branch, but if you are interested in a more detailed description, here is, [clarification from Nvidia](https://download.nvidia.com/XFree86/Linux-x86_64/435.17/README/primerenderoffload.html).