### PR TITLE
fix zink on x11 session mesa 23.3

### DIFF
--- a/data_from_portwine/scripts/runlib
+++ b/data_from_portwine/scripts/runlib
@@ -462,12 +462,22 @@ start_portwine () {
         export WINE_D3D_CONFIG='renderer=gl'
     elif [[ "${PW_VULKAN_USE}" == "5" ]] ; then
         print_info "Use OpenGL Zink"
+        if [[ "${XDG_SESSION_TYPE}" == "wayland" ]] || [[ "${PW_USE_GAMESCOPE}" == 1 ]] ; then
         export GL_YIELD="NOTHING"
         export mesa_glthread=true
         export WINE_D3D_CONFIG='renderer=gl'
         export  __GLX_VENDOR_LIBRARY_NAME=mesa
         export MESA_LOADER_DRIVER_OVERRIDE=zink
         export GALLIUM_DRIVER=zink
+        else
+        export GL_YIELD="NOTHING"
+        export mesa_glthread=true
+        export WINE_D3D_CONFIG='renderer=gl'
+        export  __GLX_VENDOR_LIBRARY_NAME=mesa
+        export MESA_LOADER_DRIVER_OVERRIDE=zink
+        export GALLIUM_DRIVER=zink
+        export LIBGL_KOPPER_DRI2=1
+        fi
     elif [[ "${PW_VULKAN_USE}" == "3" ]] ; then
         print_info "Use GALLIUM-NINE (Native DX9 on MESA drivers)"
         export PW_GALLIUM_NINE_VER="0.8"


### PR DESCRIPTION
"DRI3 not available
failed to load driver: zink
Error: couldn't get an RGB, Double-buffered visual"

on mesa 23.3+ on x11 session without this fix (Fedora 39 distribution mesa 23.3.4, vulkan radv,vk_pro,vk_amdvlk). Some problem in arch linux mesa 23.3.5 (use distrobox), working with LIBGL_KOPPER_DRI2=1. On wayland everything works fine without LIBGL_KOPPER_DRI2=1. https://gitlab.freedesktop.org/mesa/mesa/-/commit/cedb534a1763b6bd3c733d439e5d145ae6f1270e