### PR TITLE
Add version selection support OpenGL

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -2533,7 +2533,8 @@ pw_gui_for_edit_db () {
     --field=":LBL" "" \
     --field="${loc_gui_cpu_limit}!${loc_gui_cpu_limit_help} :CB" "${CPU_LIMIT_VAR}!disabled!${GET_LOGICAL_CORE}" \
     --field="${loc_gui_gpu_select}!${loc_gui_gpu_select_help} :CB" "${GPU_VAR}!disabled!${GET_GPU_NAMES}" \
-    --field="${loc_gui_arg_gamescope}!${loc_gui_arg_gamescope_help} :CBE" "\\${GAMESCOPE_ARGS}!-r 60 -F fsr!" 2>/dev/null 1> "${PORT_WINE_TMP_PATH}/tmp_output_yad_fps_limit" 2>/dev/null &
+    --field="${loc_gui_arg_gamescope}!${loc_gui_arg_gamescope_help} :CBE" "\\${GAMESCOPE_ARGS}!-r 60 -F fsr!" \
+    --field="${loc_gui_opengl_version}!${loc_gui_opengl_version_help} :CBE" "${MESA_GL_VERSION_OVERRIDE}!4.6COMPAT!4.6!4.5COMPAT!4.5!3.3COMPAT!3.3" 2>/dev/null 1> "${PORT_WINE_TMP_PATH}/tmp_output_yad_fps_limit" 2>/dev/null &
 
     "${pw_yad_v13_0}" --paned --key="$KEY_EDIT_DB_GUI" --title "EDIT_DB" --text-align=center --height="700" \
     --text "${loc_gui_edit_db} <b>${PORTWINE_DB}</b>\n ${loc_gui_edit_db_help}" --separator=" " \
@@ -2578,6 +2579,7 @@ pw_gui_for_edit_db () {
     CPU_LIMIT="$(cat "${PORT_WINE_TMP_PATH}/tmp_output_yad_fps_limit" | awk -F"%" '{print $7}')"
     PW_GPU_USE="$(cat "${PORT_WINE_TMP_PATH}/tmp_output_yad_fps_limit" | awk -F"%" '{print $8}')"
     GAMESCOPE_ARGS="$(cat "${PORT_WINE_TMP_PATH}/tmp_output_yad_fps_limit" | awk -F"%" '{print $9}')"
+    MESA_GL_VERSION_OVERRIDE="$(cat "${PORT_WINE_TMP_PATH}/tmp_output_yad_fps_limit" | awk -F"%" '{print $10}')"
     # PW_AMD_VULKAN_USE="`cat "${PORT_WINE_TMP_PATH}/tmp_output_yad_fps_limit" | awk -F"%" '{print $10}'`"
 
     if [[ "${CPU_LIMIT}" != "disabled" ]] ; then
@@ -2586,7 +2588,7 @@ pw_gui_for_edit_db () {
         export PW_WINE_CPU_TOPOLOGY="disabled"
     fi
     echo "pw_gui_for_edit_db PORTWINE_DB_FILE=$PORTWINE_DB_FILE"
-    edit_db_from_gui $@ LAUNCH_PARAMETERS PW_WINDOWS_VER PW_DLL_INSTALL WINEDLLOVERRIDES PW_WINE_CPU_TOPOLOGY GAMESCOPE_ARGS
+    edit_db_from_gui $@ LAUNCH_PARAMETERS PW_WINDOWS_VER PW_DLL_INSTALL WINEDLLOVERRIDES PW_WINE_CPU_TOPOLOGY GAMESCOPE_ARGS MESA_GL_VERSION_OVERRIDE
     if [[ -z "$MANGOHUD_CONFIG" ]] ; then
         MONITOR_HEIGHT="$(echo $PW_SCREEN_RESOLUTION | awk -F'x' '{print $2}')"
         MH_FONT_SIZE="font_size=$(( MONITOR_HEIGHT / 45 ))"

--- a/data_from_portwine/scripts/lang
+++ b/data_from_portwine/scripts/lang
@@ -353,6 +353,9 @@ if [[ "${update_loc}" == "RUS" ]] ; then
 <b>-b:</b>  создайте окно без полей.
 <b>-f:</b>  создайте полноэкранное окно."
 
+	export loc_gui_opengl_version="Принудительно выбрать версию OpenGL для игры"
+	export loc_gui_opengl_version_help="Можно выбрать необходимую версию OpenGL, некоторым играм необходим принудительный Compatibility Profile (COMPAT). (Примеры есть в выпадающем списке)"
+
 	export PW_USE_GAMESCOPE_INFO="Включение использования gamescope для запуска приложения.
 Горячие клавиши:
 
@@ -770,6 +773,9 @@ A brief instruction:
 <b>-S stretch:</b> use stretch scaling, the game will fill the window. (e.g. 4:3 to 16:9).
 <b>-b:</b> create a border-less window.
 <b>-f:</b> create a full-screen window."
+
+    export loc_gui_opengl_version="Forcibly select the OpenGL version for the game"
+    export loc_gui_opengl_version_help="You can select the required OpenGL version, some games require a forced Compatibility Profile (COMPAT). (Examples are in the drop-down list)"
 
 	export PW_USE_GAMESCOPE_INFO="
 <b>Super + F :</b> Toggle fullscreen


### PR DESCRIPTION
Some games do not work without MESA_GL_VERSION_OVERRIDE COMPAT, for example Grim Fandango Remastered. Fedora linux distribution