### PR TITLE
Use icoextract instead of wrestool (if available)

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -1441,7 +1441,9 @@ pw_create_gui_png () {
     if [[ ! -f "${PORT_WINE_PATH}/data/img/${PORTPROTON_NAME}.png" ]] ; then
         try_remove_dir "${PORT_WINE_TMP_PATH}/tmp_img"
         create_new_dir "${PORT_WINE_TMP_PATH}/tmp_img"
-        if command -v wrestool &>/dev/null ; then
+        if command -v icoextract &>/dev/null ; then
+            icoextract "$(readlink -f "${portwine_exe}")" "${PORT_WINE_TMP_PATH}/tmp_img/${PORTPROTON_NAME}.ico"
+        elif command -v wrestool &>/dev/null ; then
             wrestool -x --output="${PORT_WINE_TMP_PATH}/tmp_img/" -t14 "$(readlink -f "${portwine_exe}")"
         else
             env LD_LIBRARY_PATH="${PW_PLUGINS_PATH}/portable/lib/lib64" "${PW_PLUGINS_PATH}/portable/bin/wrestool" \


### PR DESCRIPTION
icoextract is able to extract an icon from an exe that wrestool is unable to extract an icon from.