### PR TITLE
Fixed pw_find_exe and change_locale

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -50,8 +50,7 @@ change_locale () {
         echo "en" > "${PORT_WINE_TMP_PATH}/PortProton_loc"
     fi
 
-    if [[ ! -z "${LANGUAGE}" ]] \
-    && [[ ! -f "${PORT_WINE_TMP_PATH}/PortProton_loc" ]]
+    if [[ ! -f "${PORT_WINE_TMP_PATH}/PortProton_loc" ]]
     then
         [[ ! -f "${pw_yad}" ]] && pw_yad="yad"
         SET_LANG=(
@@ -472,7 +471,7 @@ unpack () {
     if [[ "$silent" != "true" ]] ; then
         set -o pipefail
         pw_start_progress_bar_cover_block "${COVERS_PATH}/unpacking_${LANGUAGE_GIF}.gif"
-        $command "$1" -C "$2"
+        $command "$1" -C "$2" 2>/dev/null
         pw_stop_progress_bar_cover_block
         [ "${PIPESTATUS[0]}" != 0 ] && print_error "File $1 unpacking error." && return 1 || return 0
     else
@@ -1648,6 +1647,7 @@ pw_find_exe () {
     pw_start_progress_bar_block "$(gettext "Searching for .exe files... Please wait.")"
     find "${PW_PATH_FOR_FIND}" -type f -name '*.exe' ${PW_FIND_TIME} | grep -viE ${PW_EXCLUDE_EXE_FIND} | \
     awk -F"/prefixes/" '{print $2}' > "${PW_TMPFS_PATH}/tmp_yad_find_exe"
+    sleep 0.001
     pw_stop_progress_bar
 
     unset FIND_TO_GUI
@@ -3174,6 +3174,8 @@ pw_stop_progress_bar () {
     do
         kill -s SIGUSR1 "$PW_KILL_YAD_PID" &>/dev/null
     done
+    unset PW_YAD_PID_PROGRESS_BAR_BLOCK PW_YAD_PID_PROGRESS_BAR_CS \
+    PW_YAD_PID_PFX_COVER_UI PW_YAD_PID_PROGRESS_BAR_COVER
     return 0
 }
 export -f pw_stop_progress_bar


### PR DESCRIPTION
https://discord.com/channels/378683352946835456/1264655430861197436/1264655430861197436 сами баги

Дропнул if [[ ! -z "${LANGUAGE}" ]] , потому что change_loc сразу удаляет файл с языками и переменную LANGUAGE он получает из этого файла (выше). И бывают такие ситуации, если нажать на выбор язык, он удалит файл, и если язык не выбрать, и дропнуть это окно, он не создаст новый файл. А если файла нет, в следующий раз он не получит переменную LANGUAGE и не запустит это окно. Условие то что файла нет он отрабатывает, но ему ещё переменная нужна, которая формируется от этого файла

для pw_stop_progress_bar добавил unset, так как он используется для множества переменных которые остаются потом и обратно в него попадают. Добавил 0.001 sleep в том месте где багует прогресс бар, раз 5 потестил в определённых условиях, вроде бы больше нет такого.

и выхлоп с unpack отправил в  2>/dev/null, ниже него print_error есть, если распаковка не удалась 


