### PR TITLE
Fix for a bug with removing shortcuts

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -4751,15 +4751,15 @@ pw_auto_create_shortcut () {
 export -f pw_auto_create_shortcut
 
 portwine_delete_shortcut () {
-    rm -f "$(grep -il "${portwine_exe}" "${HOME}/.local/share/applications"/*.desktop)" &>/dev/null
-    rm -f "$(grep -il "${portwine_exe}" "${PORT_WINE_PATH}"/*.desktop)" &>/dev/null
-    # rm -f "$(grep -il "${portwine_exe}" "${STEAM_SCRIPTS}"/*.sh)" &>/dev/null
+    rm -f $(grep -il "${portwine_exe}" "${HOME}/.local/share/applications"/*.desktop) &>/dev/null
+    rm -f $(grep -il "${portwine_exe}" "${PORT_WINE_PATH}"/*.desktop) &>/dev/null
+    # rm -f $(grep -il "${portwine_exe}" "${STEAM_SCRIPTS}"/*.sh) &>/dev/null
     if [[ -d "${HOME}/Desktop" ]] ; then
-        rm -f "$(grep -il "${portwine_exe}" "${HOME}/Desktop"/*.desktop)" &>/dev/null
+        rm -f $(grep -il "${portwine_exe}" "${HOME}/Desktop"/*.desktop) &>/dev/null
     elif [[ -d "${HOME}/Рабочий стол" ]] ; then
-        rm -f "$(grep -il "${portwine_exe}" "${HOME}/Рабочий стол"/*.desktop)" &>/dev/null
+        rm -f $(grep -il "${portwine_exe}" "${HOME}/Рабочий стол"/*.desktop) &>/dev/null
     elif [[ $(xdg-user-dir DESKTOP) ]] ; then
-        rm -f "$(grep -il "${portwine_exe}" "$(xdg-user-dir DESKTOP)"/*.desktop)" &>/dev/null
+        rm -f $(grep -il "${portwine_exe}" "$(xdg-user-dir DESKTOP)"/*.desktop) &>/dev/null
     fi
 }
 


### PR DESCRIPTION
Если случайно создать дублирующий ярлык с другим названием на один и тот же portwine_exe файл, то удаление не будет работать, потому что в rm -f приходят два и более .desktop файла объединенных одинарными ковычками (то есть rm -f это воспринимает за один файл, а не за несколько)