### PR TITLE
Now shortcuts with spaces are deleted and when there is one with one .exe path

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -4745,16 +4745,28 @@ pw_auto_create_shortcut () {
 export -f pw_auto_create_shortcut
 
 portwine_delete_shortcut () {
-    rm -f $(grep -il "${portwine_exe}" "${HOME}/.local/share/applications"/*.desktop) &>/dev/null
-    rm -f $(grep -il "${portwine_exe}" "${PORT_WINE_PATH}"/*.desktop) &>/dev/null
-    # rm -f $(grep -il "${portwine_exe}" "${STEAM_SCRIPTS}"/*.sh) &>/dev/null
+    PW_DELETE_MENU="$(grep -il "${portwine_exe}" "${HOME}/.local/share/applications"/*.desktop 2>/dev/null)"
+    PW_DELETE_SHORTCUT+=(${PW_DELETE_MENU// /@_@})
+
+    PW_DELETE_PP="$(grep -il "${portwine_exe}" "${PORT_WINE_PATH}"/*.desktop 2>/dev/null)"
+    PW_DELETE_SHORTCUT+=(${PW_DELETE_PP// /@_@})
+
     if [[ -d "${HOME}/Desktop" ]] ; then
-        rm -f $(grep -il "${portwine_exe}" "${HOME}/Desktop"/*.desktop) &>/dev/null
-    elif [[ -d "${HOME}/Рабочий стол" ]] ; then
-        rm -f $(grep -il "${portwine_exe}" "${HOME}/Рабочий стол"/*.desktop) &>/dev/null
-    elif [[ $(xdg-user-dir DESKTOP) ]] ; then
-        rm -f $(grep -il "${portwine_exe}" "$(xdg-user-dir DESKTOP)"/*.desktop) &>/dev/null
+        PW_DELETE_DESKTOP="$(grep -il "${portwine_exe}" "${HOME}/Desktop"/*.desktop 2>/dev/null)"
+        PW_DELETE_SHORTCUT+=(${PW_DELETE_DESKTOP// /@_@})
     fi
+    if [[ -d "${HOME}/Рабочий стол" ]] ; then
+        PW_DELETE_DESKTOP="$(grep -il "${portwine_exe}" "${HOME}/Рабочий стол"/*.desktop 2>/dev/null)"
+        PW_DELETE_SHORTCUT+=(${PW_DELETE_DESKTOP// /@_@})
+    fi
+    if [[ $(xdg-user-dir DESKTOP) ]] ; then
+        PW_DELETE_DESKTOP="$(grep -il "${portwine_exe}" "$(xdg-user-dir DESKTOP)"/*.desktop 2>/dev/null)"
+        PW_DELETE_SHORTCUT+=(${PW_DELETE_DESKTOP// /@_@})
+    fi
+
+    for delete_shortcut in ${PW_DELETE_SHORTCUT[@]} ; do
+        rm -f "${delete_shortcut//@_@/ }"
+    done
 }
 
 portwine_missing_shortcut () {


### PR DESCRIPTION
После прошлого фикса для шорткатов, перестали удалятся шорткаты с пробелами, зато удалялись когда были повторы с путём до exe. Чтобы удалялось то и другое, сделал это