### PR TITLE
fix creating icon for renamed shortcut

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -1661,10 +1661,10 @@ pw_create_gui_png () {
 
     resize_png "$portwine_exe" "${PORTPROTON_NAME}" "128"
 
-    PORTPROTON_NAME_PNG="${PORTPROTON_NAME// /_}.png"
+    PORTPROTON_NAME_PNG="${PORTPROTON_NAME// /_}"
     if [[ -z "${PW_ICON_FOR_YAD}" ]] ; then
-        if [[ ! -z "$(file "${PORT_WINE_PATH}/data/img/${PORTPROTON_NAME_PNG}" | grep "${PW_RESIZE_TO} x ${PW_RESIZE_TO}")" ]] ; then
-            export PW_ICON_FOR_YAD="${PORT_WINE_PATH}/data/img/${PORTPROTON_NAME_PNG}"
+        if [[ ! -z "$(file "${PORT_WINE_PATH}/data/img/${PORTPROTON_NAME_PNG}.png" | grep "${PW_RESIZE_TO} x ${PW_RESIZE_TO}")" ]] ; then
+            export PW_ICON_FOR_YAD="${PORT_WINE_PATH}/data/img/${PORTPROTON_NAME_PNG}.png"
         else
             export PW_ICON_FOR_YAD="${PW_GUI_ICON_PATH}/port_proton.png"
         fi
@@ -4653,8 +4653,8 @@ portwine_create_shortcut () {
 
         try_remove_file "${PORT_WINE_PATH}/${name_desktop}.desktop"
 
-        if [[ "${PORTPROTON_NAME}" != "${name_desktop_png}" ]]
-        then mv -f "${PORT_WINE_PATH}/data/img/${PORTPROTON_NAME}.png" "${PORT_WINE_PATH}/data/img/${name_desktop_png}.png"
+        if [[ "${PORTPROTON_NAME_PNG}" != "${name_desktop_png}" ]]
+        then mv -f "${PORT_WINE_PATH}/data/img/${PORTPROTON_NAME_PNG}.png" "${PORT_WINE_PATH}/data/img/${name_desktop_png}.png"
         fi
 
         echo "[Desktop Entry]" > "${PORT_WINE_PATH}/${name_desktop}.desktop"


### PR DESCRIPTION
Не копировалась иконка при изменении имени ярлыка при создании.
Использовалось имя иконки с пробелами вместо имени с нижними подчёркиваниями.