### PR TITLE
Added --center yad for XFCE

### DIFF
--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -176,7 +176,11 @@ else
     source "$PW_GUI_THEMES_PATH/default.pptheme"
     echo 'export GUI_THEME="default"' >> "$USER_CONF"
 fi
-[[ "$XDG_SESSION_DESKTOP" =~ "KDE" ]] && export YAD_OPTIONS+="--center"
+if [[ "$XDG_SESSION_DESKTOP" =~ "KDE" ]] \
+|| [[ "$XDG_CURRENT_DESKTOP" == "XFCE" ]]
+then
+    export YAD_OPTIONS+="--center"
+fi
 
 # choose branch
 if [[ -z "$BRANCH" ]] ; then


### PR DESCRIPTION
Без него на xfce окно "пляшет", с ним работает нормально. Вообще бы наверное рассмотрел бы вариант для всех de по умолчанию по центру сделать, кроме gnome, если где-то будет проблема, то думаю об этом напишут))