### PR TITLE
Added --no-location for xgettext

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -100,7 +100,7 @@ generate_pot () {
         LANG_MO="${PORT_WINE_PATH}/data/locales/${lang}/LC_MESSAGES/PortProton.mo"
         TEMPLATE_POT="${PORT_WINE_PATH}/data/locales/PortProton.pot"
         pushd "${PORT_WINE_PATH}" 1>/dev/null || fatal
-        xgettext --from-code=UTF-8 --language Shell -i \
+        xgettext --no-location --from-code=UTF-8 --language Shell -i \
         "data/scripts/start.sh" \
         "data/scripts/setup.sh" \
         "data/scripts/functions_helper" \


### PR DESCRIPTION
Предлагаю добавить --no-location чтобы дропнуть в переводах комментарии с путями (на функционал это не повляет, зато пры отправлять удобнее, для старого трея перевод хотел сделать, из-за того что строки сместились, в po и pot файлах пути изменились и пр из 4 строк превратился в 300+. Ну и после этого пр генерейт пот сделать нужно