### PR TITLE
Fixed a bug when the PortProton folder remains after flatpak, native …

### DIFF
--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -82,6 +82,21 @@ fi
 # shellcheck source=/dev/null
 source "${PORT_SCRIPTS_PATH}/functions_helper"
 
+if check_flatpak
+then
+    if [[ ! -d "${HOME}/PortProton" ]] ; then
+        ln -s "${PORT_WINE_PATH}" "${HOME}/PortProton"
+    fi
+else
+    if [[ -d "${HOME}/PortProton" ]] ; then
+        if [[ $(readlink "${HOME}/PortProton") == "${HOME}/.var/app/ru.linux_gaming.PortProton" ]] ; then
+            rm -f "${HOME}/PortProton"
+            portproton
+            exit 0
+        fi
+    fi
+fi
+
 create_new_dir "${HOME}/.local/share/applications"
 if [[ "${PW_SILENT_RESTART}" == 1 ]] \
 || [[ "${START_FROM_STEAM}" == 1 ]]
@@ -373,13 +388,6 @@ else pw_download_libs
 fi
 
 pw_init_db
-
-if [[ ! -d "${HOME}/PortProton" ]] \
-&& check_flatpak 
-then
-    ln -s "${PORT_WINE_PATH}" "${HOME}/PortProton"
-fi
-
 pw_check_and_download_dxvk_and_vkd3d
 # shellcheck source=/dev/null
 source "${USER_CONF}"


### PR DESCRIPTION
У Eljeyna был какой-то баг с префиксами и дистами, насколько я понял, он связан с тем, то что он устанавливал portproton версии flatpak, portproton версии flatpak создаёт в $HOME , папку PortProton (символьную ссылку), сам он находится в $HOME/.var/app/ru.linux_gaming.PortProton. Если удалить flaptak версию PortProton, установить нативную, папка и файлы останутся (симлинк потому что ничего его не трогает, а для flatpak чтобы зачистить пользовательские данные нужно использовать команду flatpak uninstall --delete-data ) И если запустить нативную версию PortProton, то нативная будет использовать флетпаковский путь и скрипты оттуда, и почему-то у него работало некорректно. После того как он удалил файлы из .var и переустановил всё, у него работать стало нормально. По этому предлагаю если запускается версия PP нативная и если он видит символьную ссылку от флетпака, то удалять эту ссылку, чтобы он не использовал папку от flatpak 

