### PR TITLE
I made a comparison of mirrors, and every 360min the best one is selected.

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -1567,8 +1567,7 @@ pw_port_update () {
     if [[ ! -f "${PORT_WINE_TMP_PATH}/scripts_ver" ]] ; then
         echo "2024" > "${PORT_WINE_TMP_PATH}/scripts_ver"
     fi
-    scripts_install_ver=$(head -n 1 "${PORT_WINE_TMP_PATH}/scripts_ver")
-    print_info "Check update..."
+    scripts_install_ver=$(<"${PORT_WINE_TMP_PATH}/scripts_ver")
 
     URL_ETERFUND="https://gitlab.eterfund.ru/Castro-Fidel/PortWINE/raw/${BRANCH}/data_from_portwine/scripts/var"
     URL_GITHUB="https://raw.githubusercontent.com/Castro-Fidel/PortWINE/${BRANCH}/data_from_portwine/scripts/var"
@@ -1623,13 +1622,13 @@ pw_port_update () {
     if [[ ! -f "${PORT_WINE_TMP_PATH}/update_skip_mirror" ]] ; then
         pw_check_update
     else
-        CHECK_UPDATE_MIRROR=$(head -n 1 "${PORT_WINE_TMP_PATH}/update_skip_mirror")
+        CHECK_UPDATE_MIRROR=$(<"${PORT_WINE_TMP_PATH}/update_skip_mirror")
         UPDATE_SKIP_DAYS="$(echo "${CHECK_UPDATE_MIRROR}" | awk -F" " '{print $1}')"
         UPDATE_DATE_MIRROR="$(echo "${CHECK_UPDATE_MIRROR}" | awk -F" " '{print $2}')"
         UPDATE_SKIP_DATE="$(echo "${CHECK_UPDATE_MIRROR}" | awk -F" " '{print $4}')"
         UPDATE_DAYS=$(date +%-j)
         UPDATE_MINUTES=$(($(date +%-H) * 60 + $(date +%-M)))
-        if (( $((UPDATE_DATE_MIRROR + 240)) <= UPDATE_MINUTES )) \
+        if (( $((UPDATE_DATE_MIRROR + 360)) <= UPDATE_MINUTES )) \
         || [[ "$UPDATE_SKIP_DAYS" != "$UPDATE_DAYS" ]] \
         || [[ "$PW_FORCE_UPDATE" == "1" ]]
         then
@@ -1637,8 +1636,10 @@ pw_port_update () {
         fi
     fi
 
-    if (( $((UPDATE_SKIP_DATE + $(((RANDOM%31)+30)) )) <= UPDATE_MINUTES )) \
+    if (( $((UPDATE_SKIP_DATE + $(((RANDOM%11)+25)) )) <= UPDATE_MINUTES )) \
     || [[ -n "$PW_UPDATE_ALL_LIST" ]] ; then
+        print_info "Check update..."
+        echo ""
         if [[ -z "$UPDATE_URL_MIRROR" ]] ; then
             UPDATE_URL_MIRROR="$(echo "${CHECK_UPDATE_MIRROR}" | awk -F" " '{print $3}')"
             sed -i 's/[0-9]*$/'"$UPDATE_MINUTES"'/' "${PORT_WINE_TMP_PATH}/update_skip_mirror"
@@ -3988,7 +3989,7 @@ A brief instruction:
         export bool_from_yad=$(( ${bool_from_yad} + 1 ))
     done
 
-    PW_ADD_SETTINGS=$(head -n 1 "${PW_TMPFS_PATH}/tmp_output_yad_fps_limit")
+    PW_ADD_SETTINGS=$(<"${PW_TMPFS_PATH}/tmp_output_yad_fps_limit")
 
     PW_WINDOWS_VER="$(echo ${PW_ADD_SETTINGS} | awk -F"%" '{print $1}')"
     PW_DLL_INSTALL="$(echo ${PW_ADD_SETTINGS} | awk -F"%" '{print $2}')"
@@ -4535,7 +4536,7 @@ fi
         export bool_from_yad=$(( ${bool_from_yad} + 1 ))
     done
 
-    PW_ADD_SETTINGS_DGV2=$(head -n 1 "${PW_TMPFS_PATH}/tmp_yad_dgv2_set_cb")
+    PW_ADD_SETTINGS_DGV2=$(<"${PW_TMPFS_PATH}/tmp_yad_dgv2_set_cb")
 
     PW_DGV2_RESOLUTION="$(echo ${PW_ADD_SETTINGS_DGV2} | awk -F"%" '{print $1}')"
     PW_DGV2_FPS_LIMIT="$(echo ${PW_ADD_SETTINGS_DGV2} | awk -F"%" '{print $2}')"
@@ -4725,7 +4726,7 @@ relaxed - Same as fifo but allows tearing when below the monitors refresh rate."
         export bool_from_yad=$(( ${bool_from_yad} + 1 ))
     done
 
-    PW_ADD_SETTINGS_GS=$(head -n 1 "${PW_TMPFS_PATH}/tmp_yad_gs_set_cb")
+    PW_ADD_SETTINGS_GS=$(<"${PW_TMPFS_PATH}/tmp_yad_gs_set_cb")
 
     PW_GS_SHOW_RESOLUTION="$(echo ${PW_ADD_SETTINGS_GS} | awk -F"%" '{print $1}')"
     PW_GS_INTERNAL_RESOLUTION="$(echo ${PW_ADD_SETTINGS_GS} | awk -F"%" '{print $2}' | tr ',' '.')"
@@ -4827,7 +4828,7 @@ gui_userconf () {
             gui_open_user_conf
             ;;
         166)
-            PW_ADD_SETTINGS_UC=$(head -n 1 "${PW_TMPFS_PATH}/tmp_yad_userconf_set_cb")
+            PW_ADD_SETTINGS_UC=$(<"${PW_TMPFS_PATH}/tmp_yad_userconf_set_cb")
             PW_GPU_USE="$(echo ${PW_ADD_SETTINGS_UC} | awk -F"%" '{print $1}')"
             PW_SOUND_DRIVER_USE="$(echo ${PW_ADD_SETTINGS_UC} | awk -F"%" '{print $2}')"
             GUI_THEME="$(echo ${PW_ADD_SETTINGS_UC} | awk -F"%" '{print $3}')"

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -560,7 +560,9 @@ debug_timer () {
         END=$(date +%s%N)
         DIFF=$((($END - $START)/1000000))
         if [[ -n "$2" ]] ; then
-            print_warning "It took $DIFF milliseconds for $2"
+            if [[ "$2" != "-s" ]] ; then
+                print_warning "It took $DIFF milliseconds for $2"
+            fi
         else
             print_warning "It took $DIFF milliseconds"
         fi
@@ -1567,20 +1569,104 @@ pw_port_update () {
     fi
     scripts_install_ver=$(head -n 1 "${PORT_WINE_TMP_PATH}/scripts_ver")
     print_info "Check update..."
-    if curl -f -s --list-only --max-time 3 "https://gitlab.eterfund.ru/Castro-Fidel/PortWINE/raw/${BRANCH}/data_from_portwine/scripts/var" > "${PORT_WINE_TMP_PATH}/curent_var_ver"
-    then
-        URL_FOR_CHANGELOG="https://gitlab.eterfund.ru/Castro-Fidel/PortWINE/raw/${BRANCH}/data_from_portwine"
-        URL_TO_PW_BRANCH="https://gitlab.eterfund.ru/Castro-Fidel/PortWINE/-/archive/${BRANCH}/PortWINE-${BRANCH}.tar.gz"
-    else
-        if curl -f -s --list-only --max-time 3 "https://raw.githubusercontent.com/Castro-Fidel/PortWINE/${BRANCH}/data_from_portwine/scripts/var" > "${PORT_WINE_TMP_PATH}/curent_var_ver"
+
+    URL_ETERFUND="https://gitlab.eterfund.ru/Castro-Fidel/PortWINE/raw/${BRANCH}/data_from_portwine/scripts/var"
+    URL_GITHUB="https://raw.githubusercontent.com/Castro-Fidel/PortWINE/${BRANCH}/data_from_portwine/scripts/var"
+
+    pw_check_update () {
+        debug_timer --start
+        if ! timeout 3 curl -f -s --list-only "$URL_ETERFUND" > "${PORT_WINE_TMP_PATH}/curent_var_ver"
         then
-            URL_FOR_CHANGELOG="https://raw.githubusercontent.com/Castro-Fidel/PortWINE/${BRANCH}/data_from_portwine"
-            URL_TO_PW_BRANCH="https://github.com/Castro-Fidel/PortWINE/archive/refs/heads/${BRANCH}.tar.gz"
-        else
+            print_warning "https://gitlab.eterfund.ru/ broken. Skip it..."
+            UPDATE_SKIP_ETERFUND="1"
+        fi
+        debug_timer --end -s
+        UPDATE_ETERFUND="$DIFF"
+
+        debug_timer --start
+        if ! timeout 3 curl -f -s --list-only "$URL_GITHUB" > "${PORT_WINE_TMP_PATH}/curent_var_ver"
+        then
+            print_warning "https://raw.githubusercontent.com/ broken. Skip it..."
+            UPDATE_SKIP_GITHUB="1"
+        fi
+        debug_timer --end -s
+        UPDATE_GITHUB="$DIFF"
+
+        if [[ "$UPDATE_SKIP_ETERFUND" == "1" ]] \
+        && [[ "$UPDATE_SKIP_GITHUB" == "1" ]] ; then
             print_error "Unable to determine the version on the server. Skip it..."
             return 1
         fi
+
+        PW_UPDATE_ALL_LIST=($UPDATE_ETERFUND $UPDATE_GITHUB)
+
+        UPDATE_MIN=${PW_UPDATE_ALL_LIST[0]}
+        for i in "${!PW_UPDATE_ALL_LIST[@]}"; do
+        if (( ${PW_UPDATE_ALL_LIST[$i]} < UPDATE_MIN )) ; then
+            UPDATE_MIN=${PW_UPDATE_ALL_LIST[$i]}
+        fi
+        done
+
+        UPDATE_DAYS=$(date +%-j)
+        UPDATE_MINUTES=$(($(date +%-H) * 60 + $(date +%-M)))
+        if [[ "$UPDATE_ETERFUND" == "$UPDATE_MIN" ]] ; then
+            print_info "Selected https://gitlab.eterfund.ru/"
+            echo "$UPDATE_DAYS $UPDATE_MINUTES UPDATE_ETERFUND $UPDATE_MINUTES" > "${PORT_WINE_TMP_PATH}/update_skip_mirror"
+            UPDATE_URL_MIRROR="UPDATE_ETERFUND"
+        elif [[ "$UPDATE_GITHUB" == "$UPDATE_MIN" ]] ; then
+            print_info "Selected https://raw.githubusercontent.com/"
+            echo "$UPDATE_DAYS $UPDATE_MINUTES UPDATE_GITHUB $UPDATE_MINUTES" > "${PORT_WINE_TMP_PATH}/update_skip_mirror"
+            UPDATE_URL_MIRROR="UPDATE_GITHUB"
+        fi
+    }
+
+    if [[ ! -f "${PORT_WINE_TMP_PATH}/update_skip_mirror" ]] ; then
+        pw_check_update
+    else
+        CHECK_UPDATE_MIRROR=$(head -n 1 "${PORT_WINE_TMP_PATH}/update_skip_mirror")
+        UPDATE_SKIP_DAYS="$(echo "${CHECK_UPDATE_MIRROR}" | awk -F" " '{print $1}')"
+        UPDATE_DATE_MIRROR="$(echo "${CHECK_UPDATE_MIRROR}" | awk -F" " '{print $2}')"
+        UPDATE_SKIP_DATE="$(echo "${CHECK_UPDATE_MIRROR}" | awk -F" " '{print $4}')"
+        UPDATE_DAYS=$(date +%-j)
+        UPDATE_MINUTES=$(($(date +%-H) * 60 + $(date +%-M)))
+        if (( $((UPDATE_DATE_MIRROR + 240)) <= UPDATE_MINUTES )) \
+        || [[ "$UPDATE_SKIP_DAYS" != "$UPDATE_DAYS" ]] \
+        || [[ "$PW_FORCE_UPDATE" == "1" ]]
+        then
+            pw_check_update
+        fi
     fi
+
+    if (( $((UPDATE_SKIP_DATE + $(((RANDOM%31)+30)) )) <= UPDATE_MINUTES )) \
+    || [[ -n "$PW_UPDATE_ALL_LIST" ]] ; then
+        if [[ -z "$UPDATE_URL_MIRROR" ]] ; then
+            UPDATE_URL_MIRROR="$(echo "${CHECK_UPDATE_MIRROR}" | awk -F" " '{print $3}')"
+            sed -i 's/[0-9]*$/'"$UPDATE_MINUTES"'/' "${PORT_WINE_TMP_PATH}/update_skip_mirror"
+        fi
+        case "$UPDATE_URL_MIRROR" in
+            UPDATE_ETERFUND)
+                    if [[ ! -f "${PORT_WINE_TMP_PATH}/curent_var_ver" ]] \
+                    && ! timeout 3 curl -f -s --list-only "$URL_ETERFUND" > "${PORT_WINE_TMP_PATH}/curent_var_ver"
+                    then
+                        pw_check_update
+                    fi
+                    URL_FOR_CHANGELOG="https://gitlab.eterfund.ru/Castro-Fidel/PortWINE/raw/${BRANCH}/data_from_portwine"
+                    URL_TO_PW_BRANCH="https://gitlab.eterfund.ru/Castro-Fidel/PortWINE/-/archive/${BRANCH}/PortWINE-${BRANCH}.tar.gz"
+                ;;
+            UPDATE_GITHUB)
+                    if [[ ! -f "${PORT_WINE_TMP_PATH}/curent_var_ver" ]] \
+                    && ! timeout 3 curl -f -s --list-only "$URL_GITHUB" > "${PORT_WINE_TMP_PATH}/curent_var_ver"
+                    then
+                        pw_check_update
+                    fi
+                    URL_FOR_CHANGELOG="https://raw.githubusercontent.com/Castro-Fidel/PortWINE/${BRANCH}/data_from_portwine"
+                    URL_TO_PW_BRANCH="https://github.com/Castro-Fidel/PortWINE/archive/refs/heads/${BRANCH}.tar.gz"
+                ;;
+        esac
+    else
+        return 0
+    fi
+
     [[ "$LANGUAGE" == ru ]] && local PW_CHANGELOG_FILE="changelog_ru" || local PW_CHANGELOG_FILE="changelog_en"
     [[ ! -f "${PORT_WINE_TMP_PATH}/scripts_update_notifier" ]] && echo "1" > "${PORT_WINE_TMP_PATH}/scripts_update_notifier"
     read "scripts_update_not" < "${PORT_WINE_TMP_PATH}/scripts_update_notifier"
@@ -1611,7 +1697,7 @@ pw_port_update () {
                 YAD_STATUS="$?"
 
                 # --button="$(gettext "EXIT")"!"$PW_GUI_ICON_PATH/$BUTTON_SIZE.png"!"":252 \
-                
+
                 case "${YAD_STATUS}" in
                     1|252) exit 0 ;;
                        16) xcsd="$(gettext "DO NOT REMIND ME")" ;;
@@ -5501,6 +5587,7 @@ gui_rm_portproton () {
 export -f gui_rm_portproton
 
 gui_pw_update () {
+    export PW_FORCE_UPDATE="1"
     try_remove_file "${PORT_WINE_TMP_PATH}/scripts_update_notifier"
     print_info "Restarting PP for check update..."
     unset SKIP_CHECK_UPDATES

--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -162,7 +162,7 @@ export urlg="https://linux-gaming.ru/portproton/"
 export url_cloud="https://cloud.linux-gaming.ru/portproton"
 export PW_WINELIB="${PORT_WINE_TMP_PATH}/libs${PW_LIBS_VER}"
 try_remove_dir "${PW_WINELIB}/var"
-install_ver="$(head -n 1 "${PORT_WINE_TMP_PATH}/PortProton_ver")"
+install_ver="$(<"${PORT_WINE_TMP_PATH}/PortProton_ver")"
 export install_ver
 export WINETRICKS_DOWNLOADER="curl"
 export USER_CONF="${PORT_WINE_PATH}/data/user.conf"
@@ -299,7 +299,6 @@ if [[ "${SKIP_CHECK_UPDATES}" != 1 ]] ; then
             PW_SCREEN_RESOLUTION="$(<"${PW_TMPFS_PATH}/xrandr.tmp" sed -rn 's/^.*primary.* ([0-9]+x[0-9]+).*$/\1/p')"
             PW_SCREEN_PRIMARY="$(grep -e 'primary' "${PW_TMPFS_PATH}/xrandr.tmp" | awk '{print $1}')"
             export PW_SCREEN_PRIMARY PW_SCREEN_RESOLUTION
-            echo ""
             print_var PW_SCREEN_RESOLUTION PW_SCREEN_PRIMARY
         else
             print_error "xrandr - broken!"
@@ -349,7 +348,7 @@ if [[ "${SKIP_CHECK_UPDATES}" != 1 ]] ; then
     PW_FILESYSTEM=$(stat -f -c %T "${PORT_WINE_PATH}")
     export PW_FILESYSTEM
 else
-    scripts_install_ver=$(head -n 1 "${PORT_WINE_TMP_PATH}/scripts_ver")
+    scripts_install_ver=$(<"${PORT_WINE_TMP_PATH}/scripts_ver")
     export scripts_install_ver
 fi
 


### PR DESCRIPTION
1) Добавил возможность скипа выбора зеркал на определённый промежуток времени и выбирается лучшее по отклику и потом 360 минут уже не проверяет.
2) Добавил скип проверки обновлений на определённый промежуток времени. (от 25 до 35 минут будет скипать обновление в течение этого периода времени)
3) Если вдруг что-то ломается (команда дольше 3ех секунд отрабатывает), то все зеркала по новой проверяются
4) Добавил $PW_FORCE_UPDATE , с ней принудительно обновляются зеркала и проверяется обновление. (В portproton настройках где Баттон обновить, там используется)
5) + каждый день всё по новой 

360 минут можно поменять здесь UPDATE_DATE_MIRROR + 360
Обновления чекаются рандомно от 25 до 35 минут вот здесь   UPDATE_SKIP_DATE + $(((RANDOM%11)+25)) 
 (можно сделать конкретное число, к примеру UPDATE_SKIP_DATE + 60)
Сделал рандомно, чтобы распределить грубо говоря возможную нагрузку в пиковых ситуациях))

Можно сделать больше, либо меньше

30 милисекунд занимает весь скип, когда если курлить то 300

6) в 7 местах head -n 1 заменил на <, потому что в нём нет необходимости в этих местах и по тестам head -n 1  работает в 100 раз медленнее, чем < (на 1000 тестов head -n 1 2.6 секунды, < на 1000 тестов 26 милисекунд)