### PR TITLE
Added print_wrapped, added PW_DESKTOP_FILES_REGEX

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -5566,58 +5566,50 @@ pw_autoinstall_from_db () {
 }
 
 button_click () {
-    if [[ -n $(pidof -s yad) ]] || [[ -n $(pidof -s yad_gui_pp) ]] ; then
-        case "$1" in
-            --normal)
-                kill -s SIGUSR1 $(pgrep -a yad | grep "\--key=${KEY} \--notebook" | awk '{print $1}') > /dev/null 2>&1
-                ;;
-            --start)
-                kill -s SIGUSR1 $(pgrep -a yad | grep "\--key=${KEY_START} \--notebook" | awk '{print $1}') > /dev/null 2>&1 \
-                || kill -s SIGUSR1 $(pgrep -a yad | grep "\--key=${KEY_START} \--paned" | awk '{print $1}') > /dev/null 2>&1
-                ;;
-            --userconf)
-                kill -s SIGUSR1 $(pgrep -a yad | grep "\--key=${KEY_USERCONF_GUI}" | awk '{print $1}') > /dev/null 2>&1
-                ;;
-        esac
-        [[ -n "$2" ]] && echo "$2" > "${PW_TMPFS_PATH}/tmp_yad_form"
+    case "$1" in
+        --normal|--desktop)
+            kill -s SIGUSR1 $(pgrep -a yad | grep "\--key=${KEY_MENU}" | awk '{print $1}') > /dev/null 2>&1
+            ;;
+        --start)
+            kill -s SIGUSR1 $(pgrep -a yad | grep "\--key=${KEY_START}" | awk '{print $1}') > /dev/null 2>&1
+            ;;
+        --userconf)
+            kill -s SIGUSR1 $(pgrep -a yad | grep "\--key=${KEY_USERCONF_GUI}" | awk '{print $1}') > /dev/null 2>&1
+            ;;
+    esac
+
+    echo "$2" > "${PW_TMPFS_PATH}/tmp_yad_form"
+
+    if [[ "$1" == "--desktop" ]] ; then
+        PW_YAD_SET="${PORT_WINE_PATH}/${PW_YAD_SET//#@_@#/ }"
+        if [[ $PW_DESKTOP_FILES_REGEX == "1" ]] ; then
+            PW_YAD_SET="${PW_YAD_SET//#+_1#/\(}"
+            PW_YAD_SET="${PW_YAD_SET//#+_2#/\)}"
+            PW_YAD_SET="${PW_YAD_SET//#+_3#/\!}"
+            PW_YAD_SET="${PW_YAD_SET//#+_4#/\$}"
+            PW_YAD_SET="${PW_YAD_SET//#+_5#/\%}"
+            PW_YAD_SET="${PW_YAD_SET//#+_6#/\&}"
+            PW_YAD_SET="${PW_YAD_SET//#+_7#/\`}"
+            PW_YAD_SET="${PW_YAD_SET//#+_8#/\'}"
+            PW_YAD_SET="${PW_YAD_SET//#+_9#/\"}"
+            PW_YAD_SET="${PW_YAD_SET//#+_10#/\>}"
+            PW_YAD_SET="${PW_YAD_SET//#+_11#/\<}"
+            PW_YAD_SET="${PW_YAD_SET//#+_12#/\\}"
+            PW_YAD_SET="${PW_YAD_SET//#+_13#/\|}"
+            PW_YAD_SET="${PW_YAD_SET//#+_14#/\;}"
+        fi
+        if check_flatpak
+        then PW_EXEC_FROM_DESKTOP="$(grep Exec "$PW_YAD_SET" | head -n 1 | sed 's|flatpak run ru.linux_gaming.PortProton|\"${PORT_SCRIPTS_PATH}/start.sh\"|' | awk -F'=' '{print $2}')"
+        else PW_EXEC_FROM_DESKTOP="$(grep Exec "$PW_YAD_SET" | head -n 1 | awk -F"=env " '{print $2}')"
+        fi
+
+        print_info "Restarting PP after choose desktop file..."
+        # stop_portwine
+        /usr/bin/env bash -c "${PW_EXEC_FROM_DESKTOP}" &
+        exit 0
     fi
 }
 export -f button_click
-
-run_desktop_b_click () {
-    [[ -n "$1" ]] && echo "$1" > "${PW_TMPFS_PATH}/tmp_yad_form"
-
-    if [[ -n $(pidof -s yad) ]] || [[ -n $(pidof -s yad_gui_pp) ]] ; then
-        kill -s SIGUSR1 $(pgrep -a yad | grep "\--key=${KEY} \--notebook" | awk '{print $1}') > /dev/null 2>&1
-    fi
-    PW_YAD_SET="${PORT_WINE_PATH}/${PW_YAD_SET//#@_@#/ }"
-    if [[ $PW_DESKTOP_FILES_REGEX == "1" ]] ; then
-        PW_YAD_SET="${PW_YAD_SET//#+_1#/\(}"
-        PW_YAD_SET="${PW_YAD_SET//#+_2#/\)}"
-        PW_YAD_SET="${PW_YAD_SET//#+_3#/\!}"
-        PW_YAD_SET="${PW_YAD_SET//#+_4#/\$}"
-        PW_YAD_SET="${PW_YAD_SET//#+_5#/\%}"
-        PW_YAD_SET="${PW_YAD_SET//#+_6#/\&}"
-        PW_YAD_SET="${PW_YAD_SET//#+_7#/\`}"
-        PW_YAD_SET="${PW_YAD_SET//#+_8#/\'}"
-        PW_YAD_SET="${PW_YAD_SET//#+_9#/\"}"
-        PW_YAD_SET="${PW_YAD_SET//#+_10#/\>}"
-        PW_YAD_SET="${PW_YAD_SET//#+_11#/\<}"
-        PW_YAD_SET="${PW_YAD_SET//#+_12#/\\}"
-        PW_YAD_SET="${PW_YAD_SET//#+_13#/\|}"
-        PW_YAD_SET="${PW_YAD_SET//#+_14#/\;}"
-    fi
-    if check_flatpak
-    then PW_EXEC_FROM_DESKTOP="$(grep Exec "$PW_YAD_SET" | head -n 1 | sed 's|flatpak run ru.linux_gaming.PortProton|\"${PORT_SCRIPTS_PATH}/start.sh\"|' | awk -F'=' '{print $2}')"
-    else PW_EXEC_FROM_DESKTOP="$(grep Exec "$PW_YAD_SET" | head -n 1 | awk -F"=env " '{print $2}')"
-    fi
-
-    print_info "Restarting PP after choose desktop file..."
-    # stop_portwine
-    /usr/bin/env bash -c "${PW_EXEC_FROM_DESKTOP}" &
-    exit 0
-}
-export -f run_desktop_b_click
 
 gui_clear_pfx () {
     if yad_question "$(gettext "Do you want to clear prefix in PortProton?")" ; then

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -5590,9 +5590,26 @@ run_desktop_b_click () {
     if [[ -n $(pidof -s yad) ]] || [[ -n $(pidof -s yad_gui_pp) ]] ; then
         kill -s SIGUSR1 $(pgrep -a yad | grep "\--key=${KEY} \--notebook" | awk '{print $1}') > /dev/null 2>&1
     fi
+    PW_YAD_SET="${PORT_WINE_PATH}/${PW_YAD_SET//#@_@#/ }"
+    if [[ $PW_DESKTOP_FILES_REGEX == "1" ]] ; then
+        PW_YAD_SET="${PW_YAD_SET//#+_1#/\(}"
+        PW_YAD_SET="${PW_YAD_SET//#+_2#/\)}"
+        PW_YAD_SET="${PW_YAD_SET//#+_3#/\!}"
+        PW_YAD_SET="${PW_YAD_SET//#+_4#/\$}"
+        PW_YAD_SET="${PW_YAD_SET//#+_5#/\%}"
+        PW_YAD_SET="${PW_YAD_SET//#+_6#/\&}"
+        PW_YAD_SET="${PW_YAD_SET//#+_7#/\`}"
+        PW_YAD_SET="${PW_YAD_SET//#+_8#/\'}"
+        PW_YAD_SET="${PW_YAD_SET//#+_9#/\"}"
+        PW_YAD_SET="${PW_YAD_SET//#+_10#/\>}"
+        PW_YAD_SET="${PW_YAD_SET//#+_11#/\<}"
+        PW_YAD_SET="${PW_YAD_SET//#+_12#/\\}"
+        PW_YAD_SET="${PW_YAD_SET//#+_13#/\|}"
+        PW_YAD_SET="${PW_YAD_SET//#+_14#/\;}"
+    fi
     if check_flatpak
-    then PW_EXEC_FROM_DESKTOP="$(grep Exec "${PORT_WINE_PATH}/${PW_YAD_SET//@_@/ }" | head -n 1 | sed 's|flatpak run ru.linux_gaming.PortProton|\"${PORT_SCRIPTS_PATH}/start.sh\"|' | awk -F'=' '{print $2}')"
-    else PW_EXEC_FROM_DESKTOP="$(grep Exec "${PORT_WINE_PATH}/${PW_YAD_SET//@_@/ }" | head -n 1 | awk -F"=env " '{print $2}')"
+    then PW_EXEC_FROM_DESKTOP="$(grep Exec "$PW_YAD_SET" | head -n 1 | sed 's|flatpak run ru.linux_gaming.PortProton|\"${PORT_SCRIPTS_PATH}/start.sh\"|' | awk -F'=' '{print $2}')"
+    else PW_EXEC_FROM_DESKTOP="$(grep Exec "$PW_YAD_SET" | head -n 1 | awk -F"=env " '{print $2}')"
     fi
 
     print_info "Restarting PP after choose desktop file..."

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -18,6 +18,27 @@ export -f print_ok
 print_var () { for vp in $@ ; do print_info "${vp}=${!vp}" ; done ;}
 export -f print_var
 
+print_wrapped () {
+    local text="$1"
+    local a="0"
+    local b="$2"
+    local c="$3"
+
+    if [[ -n "$c" ]] ; then
+        if (( ${#text} > b )); then
+            echo "${text:a:b}${c}"
+        else
+            echo "$text"
+        fi
+    else
+        while (( a < ${#text} )) ; do
+            echo "${text:a:b}"
+            ((a+=b))
+        done
+    fi
+}
+export -f print_wrapped
+
 check_variables () { [[ -z ${!1} ]] && export $1="$2" ;}
 
 add_to_var () {
@@ -5157,13 +5178,16 @@ portwine_missing_shortcut () {
     "${pw_yad}" --title="$(gettext "Error")" --form \
     --window-icon "$PW_GUI_ICON_PATH/portproton.svg" --fixed \
     --image "$PW_GUI_ICON_PATH/error.svg" \
-    --text "\n$(gettext "Could not find the file:")\n${portwine_exe}\n\n$(gettext "ATTENTION:\nIf you forgot to mount the disk with the running application, click CANCEL!")\n" \
+    --text "\n$(gettext "Could not find the file:")\n$(print_wrapped "${portwine_exe}" "50")\n\n$(gettext "ATTENTION:\nIf you forgot to mount the disk with the running application, click CANCEL!")\n" \
     --button="$(gettext "DELETE SHORTCUT")"!"$PW_GUI_ICON_PATH/$BUTTON_SIZE.png":0 \
     --button="$(gettext "CANCEL")"!"$PW_GUI_ICON_PATH/$BUTTON_SIZE.png":1
     if [[ $? -eq "0" ]] ; then
         portwine_delete_shortcut
     fi
-    exit 0
+    if [[ -n "$TAB_MAIN_MENU" ]]
+    then restart_pp
+    else exit 0
+    fi
 }
 
 # GUI WINETRICKS | GUI PREFIX MANAGER

--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -695,7 +695,7 @@ else
         gui_userconf
     fi
 
-    export KEY="$RANDOM"
+    export KEY_MENU="$RANDOM"
 
     IFS=$'\n'
     PW_GENERATE_BUTTONS="--field=   $(gettext "Create shortcut...")!${PW_GUI_ICON_PATH}/find_48.svg!:FBTN%@bash -c \"button_click --normal pw_find_exe\"%"
@@ -739,17 +739,17 @@ else
         else
             PW_DESKTOP_FILES_SHOW="${PW_DESKTOP_FILES}"
         fi
-        PW_GENERATE_BUTTONS+="--field=   $(print_wrapped "${PW_DESKTOP_FILES_SHOW//".desktop"/""}" "20" "...")!${PW_NAME_D_ICON_48}.png!:FBTN%@bash -c \"run_desktop_b_click "${PW_DESKTOP_FILES// /#@_@#}"\"%"
+        PW_GENERATE_BUTTONS+="--field=   $(print_wrapped "${PW_DESKTOP_FILES_SHOW//".desktop"/""}" "20" "...")!${PW_NAME_D_ICON_48}.png!:FBTN%@bash -c \"button_click --desktop "${PW_DESKTOP_FILES// /#@_@#}"\"%"
     done
     IFS="$orig_IFS"
 
     IFS="%"
-    "${pw_yad}" --plug=$KEY --tabnum="${PW_GUI_SORT_TABS[4]}" --form --columns="$MAIN_GUI_COLUMNS" --homogeneous-column \
+    "${pw_yad}" --plug=$KEY_MENU --tabnum="${PW_GUI_SORT_TABS[4]}" --form --columns="$MAIN_GUI_COLUMNS" --homogeneous-column \
     --gui-type-layout="${MAIN_MENU_GUI_TYPE_LAYOUT}" \
     --align-buttons --scroll --separator=" " ${PW_GENERATE_BUTTONS} 2>/dev/null &
     IFS="$orig_IFS"
 
-    "${pw_yad}" --plug=$KEY --tabnum="${PW_GUI_SORT_TABS[3]}" --form --columns=3 --align-buttons --separator=";" --homogeneous-column \
+    "${pw_yad}" --plug=$KEY_MENU --tabnum="${PW_GUI_SORT_TABS[3]}" --form --columns=3 --align-buttons --separator=";" --homogeneous-column \
     --gui-type-layout="${MAIN_MENU_GUI_TYPE_LAYOUT}" \
     --field="   $(gettext "Reinstall PortProton")"!"$PW_GUI_ICON_PATH/$BUTTON_SIZE_MM.png"!"":"FBTN" '@bash -c "button_click --normal gui_pw_reinstall_pp"' \
     --field="   $(gettext "Remove PortProton")"!"$PW_GUI_ICON_PATH/$BUTTON_SIZE_MM.png"!"":"FBTN" '@bash -c "button_click --normal gui_rm_portproton"' \
@@ -762,7 +762,7 @@ else
     --field="   $(gettext "Credits")"!"$PW_GUI_ICON_PATH/$BUTTON_SIZE_MM.png"!"":"FBTN" '@bash -c "button_click --normal gui_credits"' \
     2>/dev/null &
 
-    "${pw_yad}" --plug=$KEY --tabnum="${PW_GUI_SORT_TABS[2]}" --form --columns=3 --align-buttons --separator=";" \
+    "${pw_yad}" --plug=$KEY_MENU --tabnum="${PW_GUI_SORT_TABS[2]}" --form --columns=3 --align-buttons --separator=";" \
     --gui-type-layout="${MAIN_MENU_GUI_TYPE_LAYOUT}" \
     --field="   3D API  : :CB" "${PW_DEFAULT_VULKAN_USE}" \
     --field="   PREFIX  : :CBE" "${PW_ADD_PREFIXES_TO_GUI}" \
@@ -777,7 +777,7 @@ else
     --field="   $(gettext "Command line")"!"$PW_GUI_ICON_PATH/$BUTTON_SIZE_MM.png"!"$(gettext "Run wine cmd")":"FBTN" '@bash -c "button_click --normal WINECMD"' \
     --field="   $(gettext "Regedit")"!"$PW_GUI_ICON_PATH/$BUTTON_SIZE_MM.png"!"$(gettext "Run wine regedit")":"FBTN" '@bash -c "button_click --normal WINEREG"' 1> "${PW_TMPFS_PATH}/tmp_yad_form_vulkan" 2>/dev/null &
 
-    "${pw_yad}" --plug=$KEY --tabnum="${PW_GUI_SORT_TABS[1]}" --form --columns="$MAIN_GUI_COLUMNS" --align-buttons --scroll --homogeneous-column \
+    "${pw_yad}" --plug=$KEY_MENU --tabnum="${PW_GUI_SORT_TABS[1]}" --form --columns="$MAIN_GUI_COLUMNS" --align-buttons --scroll --homogeneous-column \
     --gui-type-layout="${MAIN_MENU_GUI_TYPE_LAYOUT}" \
     --field="   Dolphin 5.0"!"$PW_GUI_ICON_PATH/dolphin.png"!"$(gettext "Emulator for Nintendo game consoles with high compatibility")":"FBTN" '@bash -c "button_click --normal PW_DOLPHIN"' \
     --field="   MAME"!"$PW_GUI_ICON_PATH/mame.png"!"$(gettext "Multi-arcade emulator that allows you to play old arcade games")":"FBTN" '@bash -c "button_click --normal PW_MAME"' \
@@ -794,7 +794,7 @@ else
     --field="   xemu"!"$PW_GUI_ICON_PATH/xemu.png"!"$(gettext "Emulator for the Xbox game console")":"FBTN" '@bash -c "button_click --normal PW_XEMU"' \
     --field="   Demul"!"$PW_GUI_ICON_PATH/demul.png"!"$(gettext "Emulator for the Sega Dreamcast game console")":"FBTN" '@bash -c "button_click --normal PW_DEMUL"' 2>/dev/null &
 
-    "${pw_yad}" --plug=$KEY --tabnum="${PW_GUI_SORT_TABS[0]}" --form --columns="$MAIN_GUI_COLUMNS" --align-buttons --scroll --homogeneous-column \
+    "${pw_yad}" --plug=$KEY_MENU --tabnum="${PW_GUI_SORT_TABS[0]}" --form --columns="$MAIN_GUI_COLUMNS" --align-buttons --scroll --homogeneous-column \
     --gui-type-layout="${MAIN_MENU_GUI_TYPE_LAYOUT}" \
     --field="   Lesta Game Center"!"$PW_GUI_ICON_PATH/lgc.png"!"":"FBTN" '@bash -c "button_click --normal PW_LGC"' \
     --field="   vkPlay Games Center"!"$PW_GUI_ICON_PATH/mygames.png"!"":"FBTN" '@bash -c "button_click --normal PW_VKPLAY"' \
@@ -845,7 +845,7 @@ else
     fi
 
     if [[ -z "${PW_ALL_DF}" ]] ; then
-        "${pw_yad}" --key=$KEY --notebook --expand \
+        "${pw_yad}" --key=$KEY_MENU --notebook --expand \
         --gui-type="settings-notebook" --active-tab="${TAB_MAIN_MENU}" \
         --width="${PW_MAIN_SIZE_W}" --height="${PW_MAIN_SIZE_H}" --no-buttons \
         --window-icon="$PW_GUI_ICON_PATH/portproton.svg" \
@@ -858,7 +858,7 @@ else
         --tab="$(gettext "INSTALLED")"!"$PW_GUI_ICON_PATH/$TAB_SIZE.png"!"" 2>/dev/null
         YAD_STATUS="$?"
     else
-        "${pw_yad}" --key=$KEY --notebook --expand \
+        "${pw_yad}" --key=$KEY_MENU --notebook --expand \
         --gui-type="settings-notebook" --active-tab="${TAB_MAIN_MENU}" \
         --width="${PW_MAIN_SIZE_W}" --height="${PW_MAIN_SIZE_H}" --no-buttons \
         --window-icon="$PW_GUI_ICON_PATH/portproton.svg" \
@@ -950,7 +950,7 @@ esac
     pw_start_cont_xterm) pw_start_cont_xterm ;;
     pw_find_exe) pw_find_exe ;;
     PW_*) pw_autoinstall_from_db ;;
-    *.desktop) run_desktop_b_click ;;
+    *.desktop) button_click --desktop ;;
     1|252|*) exit 0 ;;
 esac
 

--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -99,6 +99,7 @@ unset PW_PREFIX_NAME WINEPREFIX VULKAN_MOD PW_WINE_VER PW_ADD_TO_ARGS_IN_RUNTIME
 unset PW_NAME_D_NAME PW_NAME_D_ICON PW_NAME_D_EXEC PW_EXEC_FROM_DESKTOP PW_ALL_DF PW_GENERATE_BUTTONS PW_NAME_D_ICON PW_NAME_D_ICON_48
 unset MANGOHUD_CONFIG FPS_LIMIT PW_WINE_USE WINEDLLPATH WINE WINEDIR WINELOADER WINESERVER PW_USE_RUNTIME PORTWINE_CREATE_SHORTCUT_NAME MIRROR
 unset PW_LOCALE_SELECT PW_SETTINGS_INDICATION PW_GUI_START PW_AUTOINSTALL_EXE NOSTSTDIR RADV_DEBUG PW_NO_AUTO_CREATE_SHORTCUT
+unset PW_DESKTOP_FILES_REGEX
 
 export PORT_WINE_TMP_PATH="${PORT_WINE_PATH}/data/tmp"
 rm -f "$PORT_WINE_TMP_PATH"/*{exe,msi,tar}*
@@ -581,7 +582,7 @@ if [[ -f "${portwine_exe}" ]] ; then
     fi
     if [[ "${PW_GUI_DISABLED_CS}" != 1 ]] ; then
         pw_create_gui_png
-        if ! grep -il "${portwine_exe}" "${HOME}/.local/share/applications"/*.desktop ; then
+        if ! grep -il "${portwine_exe}" "${HOME}/.local/share/applications"/*.desktop &>/dev/null ; then
             PW_SHORTCUT="$(gettext "CREATE SHORTCUT")!$PW_GUI_ICON_PATH/$BUTTON_SIZE.png!$(gettext "Create shortcut for select file..."):100"
         else
             PW_SHORTCUT="$(gettext "DELETE SHORTCUT")!$PW_GUI_ICON_PATH/$BUTTON_SIZE.png!$(gettext "Delete shortcut for select file..."):98"
@@ -713,7 +714,32 @@ else
             resize_png "${PW_NAME_D_ICON}" "${PW_NAME_D_ICON_48//"${PORT_WINE_PATH}/data/img/"/}" "48"
             resize_png "${PW_NAME_D_ICON}" "${PW_NAME_D_ICON_128//"${PORT_WINE_PATH}/data/img/"/}" "128"
         fi
-        PW_GENERATE_BUTTONS+="--field=   $(print_wrapped "${PW_DESKTOP_FILES//".desktop"/""}" "20" "...")!${PW_NAME_D_ICON_48}.png!:FBTN%@bash -c \"run_desktop_b_click "${PW_DESKTOP_FILES// /@_@}"\"%"
+        if [[ $PW_DESKTOP_FILES =~ [\(\)\!\$\%\&\`\'\"\>\<\\\|\;] ]] ; then
+            export PW_DESKTOP_FILES_REGEX="1"
+            PW_DESKTOP_FILES_SHOW="${PW_DESKTOP_FILES//\!/}"
+            PW_DESKTOP_FILES_SHOW="${PW_DESKTOP_FILES_SHOW//\%/}"
+            PW_DESKTOP_FILES_SHOW="${PW_DESKTOP_FILES_SHOW//\$/}"
+            PW_DESKTOP_FILES_SHOW="${PW_DESKTOP_FILES_SHOW//\&/}"
+            PW_DESKTOP_FILES_SHOW="${PW_DESKTOP_FILES_SHOW//\</}"
+
+            PW_DESKTOP_FILES="${PW_DESKTOP_FILES//\(/#+_1#}"
+            PW_DESKTOP_FILES="${PW_DESKTOP_FILES//\)/#+_2#}"
+            PW_DESKTOP_FILES="${PW_DESKTOP_FILES//\!/#+_3#}"
+            PW_DESKTOP_FILES="${PW_DESKTOP_FILES//\$/#+_4#}"
+            PW_DESKTOP_FILES="${PW_DESKTOP_FILES//\%/#+_5#}"
+            PW_DESKTOP_FILES="${PW_DESKTOP_FILES//\&/#+_6#}"
+            PW_DESKTOP_FILES="${PW_DESKTOP_FILES//\`/#+_7#}"
+            PW_DESKTOP_FILES="${PW_DESKTOP_FILES//\'/#+_8#}"
+            PW_DESKTOP_FILES="${PW_DESKTOP_FILES//\"/#+_9#}"
+            PW_DESKTOP_FILES="${PW_DESKTOP_FILES//\>/#+_10#}"
+            PW_DESKTOP_FILES="${PW_DESKTOP_FILES//\</#+_11#}"
+            PW_DESKTOP_FILES="${PW_DESKTOP_FILES//\\/#+_12#}"
+            PW_DESKTOP_FILES="${PW_DESKTOP_FILES//\|/#+_13#}"
+            PW_DESKTOP_FILES="${PW_DESKTOP_FILES//\;/#+_14#}"
+        else
+            PW_DESKTOP_FILES_SHOW="${PW_DESKTOP_FILES}"
+        fi
+        PW_GENERATE_BUTTONS+="--field=   $(print_wrapped "${PW_DESKTOP_FILES_SHOW//".desktop"/""}" "20" "...")!${PW_NAME_D_ICON_48}.png!:FBTN%@bash -c \"run_desktop_b_click "${PW_DESKTOP_FILES// /#@_@#}"\"%"
     done
     IFS="$orig_IFS"
 

--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -52,7 +52,7 @@ then
 elif [[ "$1" == *.[Ee][Xx][Ee] || "$1" == *.[Bb][Aa][Tt] || "$1" == *.[Mm][Ss][Ii] || "$1" == *.[Rr][Ee][Gg] ]]
 then
     portwine_exe="$1"
-    MISSING_DESKTOP_FILE=1
+    MISSING_DESKTOP_FILE="1"
 fi
 export portwine_exe
 
@@ -404,7 +404,7 @@ fi
 
 export SKIP_CHECK_UPDATES="1"
 
-[[ "$MISSING_DESKTOP_FILE" == 1 ]] && portwine_missing_shortcut
+[[ "$MISSING_DESKTOP_FILE" == "1" ]] && portwine_missing_shortcut
 
 if [[ -n $(basename "${portwine_exe}" | grep .ppack) ]] ; then
     unset PW_SANDBOX_HOME_PATH
@@ -548,9 +548,9 @@ esac
 
 if [[ -z "${PW_COMMENT_DB}" ]] ; then
     if [[ -n "${PORTPROTON_NAME}" ]] ; then
-        PW_COMMENT_DB="$(gettext "Launching") <b>${PORTPROTON_NAME}</b>"
+        PW_COMMENT_DB="$(gettext "Launching") <b>$(print_wrapped "${PORTPROTON_NAME}" "50")</b>"
     else
-        PW_COMMENT_DB="$(gettext "Launching") <b>${PORTWINE_DB}</b>"
+        PW_COMMENT_DB="$(gettext "Launching") <b>$(print_wrapped "${PORTWINE_DB}" "50")</b>"
     fi
 fi
 
@@ -713,7 +713,7 @@ else
             resize_png "${PW_NAME_D_ICON}" "${PW_NAME_D_ICON_48//"${PORT_WINE_PATH}/data/img/"/}" "48"
             resize_png "${PW_NAME_D_ICON}" "${PW_NAME_D_ICON_128//"${PORT_WINE_PATH}/data/img/"/}" "128"
         fi
-        PW_GENERATE_BUTTONS+="--field=   ${PW_DESKTOP_FILES//".desktop"/""}!${PW_NAME_D_ICON_48}.png!:FBTN%@bash -c \"run_desktop_b_click "${PW_DESKTOP_FILES// /@_@}"\"%"
+        PW_GENERATE_BUTTONS+="--field=   $(print_wrapped "${PW_DESKTOP_FILES//".desktop"/""}" "20" "...")!${PW_NAME_D_ICON_48}.png!:FBTN%@bash -c \"run_desktop_b_click "${PW_DESKTOP_FILES// /@_@}"\"%"
     done
     IFS="$orig_IFS"
 


### PR DESCRIPTION
1) Пр основан исходя из этой темы https://discord.com/channels/378683352946835456/1286571280627400735
Изначально нужно рассмотреть/принять https://github.com/Castro-Fidel/PortWINE/pull/335 этот пр, потому что могут (и скорее всего будут конфликты и по ссылке пр править сложнее потом будет, чем этот).
Логика работы где просто $2 (к примеру "50"), то будет переносить на следующую строку после 50 символов, где с $3, то переноса не будет, в конце будет обрезаться текст на то что в $3 (в $c) находится

2) Так же добавил возврат на главное меню, при удалении битого ярлыка, если PP был запущен уже. При удалении с рабочего стола или ещё откуда-то, будет как обычно exit 0 (сделал так, потому что PP более интерактивный в плане взаимодействия с другими страницами стал, и если у человека 10 битых десктоп файлов, с возратом в главное меню их проще будет удалить, чем каждый раз заново запускать PP)

3) Добавил PW_DESKTOP_FILES_REGEX, суть заключается в том, то что если название .desktop файла содержит разного рода символы, то они не нажимаются, некоторые из них так вообще полностью ломают баттоны у yad
(~`!@"№;:?#$%^&*()-_=+\|]][[}{}{[];:'"⁄?.>,<,.,.desktop такой desktop файл теперь работает, до этого 1 символа было достаточно, чтобы всё сломать)

4) Дропнул run_desktop_b_click, интегрировал его в button_click,  убрал разные проверки для button_click (скорее всего они излишне ...)
pidof 30-40 милисекунд занимает, нужен ли он здесь ))