### PR TITLE
Added uptime skip

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -3141,7 +3141,7 @@ start_portwine () {
         if [[ -d /sys/bus/pci/drivers/amdgpu ]] ; then
             export RADV_DEBUG+="nodcc "
             export AMD_DEBUG="nodcc"
-            if ! grep -q VK_EXT_image_drm_format_modifier "${PW_TMPFS_PATH}/vulkaninfo.tmp" ; then
+            if [[ $VK_EXT_IMAGE_DRM_FORMAT == "0" ]] ; then
                 export R600_DEBUG="nodcc"
                 grep -e '--backend' "${PW_TMPFS_PATH}/gamescope.tmp" &>/dev/null && PW_GS_BACKEND_SDL="1"
             fi


### PR DESCRIPTION
Команда uptime -s показывает время запуска компьютера. По логике вещей, видеокарту и lspci чекает 3d/vga устройство, и по логике вещей скорее всего при включенном компьютере думаю никто не будет менять одну видеокарту на другую или вставлять в компьютер ещё одну (или перепаивать vga чип при включенном ноутбуке), а так время первичного запуска пп без скипа 300 мс у меня занимает, со скипом 140 мс

Убрал в draft чтобы рассмотреть нештатные сценарии развития событий