### PR TITLE
Added PW_STOP_PORTWINE_RESTART

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -675,6 +675,31 @@ check_flatpak () {
 }
 export -f check_flatpak
 
+background_pid () {
+    local arg1=$1 # --start или --end
+    local arg2=$2 # Название команды
+    local arg3=$3 # Номер процесса (1,2,3..)
+    get_bg_pid () {
+        eval "echo \${$1}"
+    }
+
+    if [[ "$arg1" == --start ]] ; then
+        eval "$arg2 &"
+        PID=$!
+        export bg_pid"${arg3}"="$PID"
+    elif [[ "$arg1" == --end ]] ; then
+        PID=$(get_bg_pid bg_pid"${arg3}")
+        [[ $PID == "" ]] && return 1
+        while true ; do
+            if [[ ! $(jobs -p) =~ $PID ]] ; then
+                return 0
+            fi
+            sleep 0.005
+        done
+    fi
+}
+export -f background_pid
+
 unpack () {
     case $1 in
          *.tar.xz) local command="tar -Jxhf";;
@@ -1952,11 +1977,7 @@ pw_skip_update () {
 
 pw_skip_update_new () {
     if [[ "${SKIP_CHECK_UPDATES_NEW}" != "1" ]] ; then
-        while true ; do
-            if [[ ! $(jobs -p) =~ $PID_SKIP_UPDATE ]] ; then
-                break
-            fi
-        done
+        background_pid --end "pw_skip_update" "1"
 
         if [[ -f "${PW_TMPFS_PATH}/gamescope.tmp" ]] ; then
             export GAMESCOPE_INSTALLED="1"
@@ -5563,9 +5584,9 @@ portwine_start_debug () {
     kill_portwine
     export PW_LOG=1
     if [[ -z "$VULKAN_DRIVER_NAME" ]] || [[ "$VULKAN_DRIVER_NAME" == "llvmpipe" ]] ; then
-    pw_notify_send -i warning \
-    "${translations[Attention working version of vulkan not detected!]}" \
-    "${translations[It is recommended to run games in OpenGL (low performance possible)!]}"
+        pw_notify_send -i warning \
+        "${translations[Attention working version of vulkan not detected!]}" \
+        "${translations[It is recommended to run games in OpenGL (low performance possible)!]}"
     fi
     echo "${translations[PortProton was launched in creation mode PortProton.log and it is successfully stored in the root directory of the port]}" > "${PORT_WINE_PATH}/PortProton.log"
     echo "${translations[To diagnose the problem, copy ALL of the log to discord server: https://discord.gg/FTaheP99wE]}" >> "${PORT_WINE_PATH}/PortProton.log"

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -1266,7 +1266,11 @@ stop_portwine () {
     pw_auto_create_shortcut
     add_in_stop_portwine
     unset SKIP_CHECK_UPDATES
-    exit 0
+    if [[ "$PW_STOP_PORTWINE_RESTART" == 1 ]] ; then
+        restart_pp
+    else
+        exit 0
+    fi
 }
 export -f stop_portwine
 
@@ -2199,6 +2203,7 @@ pw_create_unique_exe () {
 }
 
 start_portwine () {
+    pw_skip_update_new
     if [[ "${PW_LOCALE_SELECT}" != "disabled" ]] && [[ -n "${PW_LOCALE_SELECT}" ]] ; then
         export LC_ALL="${PW_LOCALE_SELECT}"
         if [[ "${PW_USE_RUNTIME}" == "1" ]] && [[ "${HOST_LC_ALL}" != "${LC_ALL}" ]] ; then
@@ -3495,7 +3500,6 @@ pw_yad_form_vulkan () {
 }
 
 portwine_launch () {
-    pw_skip_update_new
     start_portwine
     unset PW_VD_TMP
     if [[ "${PW_VIRTUAL_DESKTOP}" == "1" ]] ; then
@@ -3526,11 +3530,15 @@ pw_winecfg () {
     start_portwine
     export GST_PLUGIN_SYSTEM_PATH_1_0=""
     pw_run winecfg
+    export PW_STOP_PORTWINE_RESTART=1
+    stop_portwine
 }
 
 pw_winefile () {
     start_portwine
     pw_run winefile
+    export PW_STOP_PORTWINE_RESTART=1
+    stop_portwine
 }
 
 pw_winecmd () {
@@ -3538,6 +3546,7 @@ pw_winecmd () {
     start_portwine
     cd "${PORT_WINE_PATH}/data/prefixes/${PW_PREFIX_NAME}/drive_c" || fatal
     pw_run cmd
+    export PW_STOP_PORTWINE_RESTART=1
     stop_portwine
 }
 
@@ -3545,6 +3554,8 @@ pw_winereg () {
     start_portwine
     export GST_PLUGIN_SYSTEM_PATH_1_0=""
     pw_run regedit
+    export PW_STOP_PORTWINE_RESTART=1
+    stop_portwine
 }
 
 pw_start_cont_xterm () {
@@ -3558,6 +3569,7 @@ pw_start_cont_xterm () {
     ${PW_GAMEMODERUN_SLR} \
     ${PW_MANGOHUD_SLR} \
     ${PW_TERM} bash
+    restart_pp
 }
 
 # GUI INFO

--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -102,7 +102,7 @@ unset PW_PREFIX_NAME WINEPREFIX VULKAN_MOD PW_WINE_VER PW_ADD_TO_ARGS_IN_RUNTIME
 unset PW_NAME_D_NAME PW_NAME_D_ICON PW_NAME_D_EXEC PW_EXEC_FROM_DESKTOP PW_ALL_DF PW_GENERATE_BUTTONS PW_NAME_D_ICON PW_NAME_D_ICON_48
 unset MANGOHUD_CONFIG FPS_LIMIT PW_WINE_USE WINEDLLPATH WINE WINEDIR WINELOADER WINESERVER PW_USE_RUNTIME PORTWINE_CREATE_SHORTCUT_NAME MIRROR
 unset PW_LOCALE_SELECT PW_SETTINGS_INDICATION PW_GUI_START PW_AUTOINSTALL_EXE NOSTSTDIR RADV_DEBUG PW_NO_AUTO_CREATE_SHORTCUT
-unset PW_DESKTOP_FILES_REGEX
+unset PW_DESKTOP_FILES_REGEX PW_STOP_PORTWINE_RESTART
 
 export PORT_WINE_TMP_PATH="${PORT_WINE_PATH}/data/tmp"
 rm -f "$PORT_WINE_TMP_PATH"/*{exe,msi,tar}*
@@ -660,7 +660,6 @@ else
         fi
         PW_GENERATE_BUTTONS+="--field=   $(print_wrapped "${PW_DESKTOP_FILES_SHOW//".desktop"/""}" "25" "...")!${PW_NAME_D_ICON_48}.png!:FBTN%@bash -c \"button_click --desktop "${PW_DESKTOP_FILES// /#@_@#}"\"%"
     done
-    IFS="$orig_IFS"
 
     IFS="%"
     "${pw_yad}" --plug=$KEY_MENU --tabnum="${PW_GUI_SORT_TABS[4]}" --form --columns="$MAIN_GUI_COLUMNS" --homogeneous-column \
@@ -813,7 +812,7 @@ fi
     gui_pw_reinstall_pp|open_changelog|\
     128|gui_pw_update|\
     change_loc|gui_open_scripts_from_backup|\
-    gui_credits)
+    gui_credits|pw_start_cont_xterm)
         if [[ -z "${PW_ALL_DF}" ]] ; then
             export TAB_MAIN_MENU="4"
         else
@@ -822,7 +821,8 @@ fi
         ;;
     gui_proton_downloader|WINETRICKS|\
     116|pw_create_prefix_backup|\
-    gui_clear_pfx)
+    gui_clear_pfx|WINEREG|WINECMD|\
+    WINEFILE|WINECFG)
         if [[ -z "${PW_ALL_DF}" ]] ; then
             export TAB_MAIN_MENU="3"
         else

--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -267,9 +267,7 @@ if [[ "${SKIP_CHECK_UPDATES}" != 1 ]] ; then
     PW_FILESYSTEM=$(stat -f -c %T "${PORT_WINE_PATH}")
     export PW_FILESYSTEM
 
-    pw_skip_update &
-    PID_SKIP_UPDATE=$(jobs -p)
-    export PID_SKIP_UPDATE="${PID_SKIP_UPDATE//*[[:space:]]/}"
+    background_pid --start "pw_skip_update" "1"
 fi
 
 # create lock file


### PR DESCRIPTION
Добавил PW_STOP_PORTWINE_RESTART, чтобы при stop_portwine можно было делать restart_pp.
Для чего это нужно, чтобы после выхода из настроек префикса, файлового менеджера, командной строки, редактора реестра, не нужно было заново запускать PP, и само возвращало в главное в меню. Так же добавил на xterm возврат в главное меню. Для всех них сделал возврат в нужный таб. pw_skip_update_new перенес в start_portwine 

IFS="$orig_IFS" дропнул, после него  IFS="%". Смысл от первого ))

Добавил функцию background_pid (для того чтобы проще было отправлять что-то в фон и на каком-то этапе потом ловить этот процесс, возможно пригодится)