### PR TITLE
Fixes for NEW_DESKTOP and  portwine_start_debug

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -806,8 +806,11 @@ search_desktop_file () {
                         echo "#NEW_DESKTOP" >> "$desktop_file"
                         TIME_CURRENT="0"
                     # Для битых #Time=
-                    elif [[ ! $TIME_CURRENT == "" ]] && [[ ! $TIME_CURRENT =~ [0-9]+ ]] ; then
-                        TIME_CURRENT="0"
+                    else
+                        if [[ ! $TIME_CURRENT =~ [0-9]+ ]] \
+                        || (( $TIME_CURRENT >= 999999999 )) ; then
+                            TIME_CURRENT="0"
+                        fi
                     fi
                     TIME_CURRENT_ARRAY+=($TIME_CURRENT)
                     unset TIME_CURRENT
@@ -1455,9 +1458,11 @@ stop_portwine () {
     pw_auto_create_shortcut
     add_in_stop_portwine
 
-    debug_timer --end -s "PW_TIME_IN_GAME"
-    PW_TIME_IN_GAME=$(( PW_TIME_IN_GAME / 1000 )) # в секундах
-    search_desktop_file
+    if [[ $PW_LOG != 1 ]] ; then
+        debug_timer --end -s "PW_TIME_IN_GAME"
+        PW_TIME_IN_GAME=$(( PW_TIME_IN_GAME / 1000 )) # в секундах
+        search_desktop_file
+    fi
 
     case "$1" in
         --restart)
@@ -3688,7 +3693,7 @@ portwine_launch () {
         PW_VD_TMP=(explorer "/desktop=PortProton,${PW_SCREEN_RESOLUTION}")
     fi
 
-    debug_timer --start -s "PW_TIME_IN_GAME"
+    [[ $PW_LOG != 1 ]] && debug_timer --start -s "PW_TIME_IN_GAME"
     case "$portwine_exe" in
         *.[Ee][Xx][Ee])
             pw_run ${PW_VD_TMP[@]} ${WINE_WIN_START} "$portwine_exe"

--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -644,7 +644,8 @@ else
                     PW_AMOUNT_OLD_DESKTOP+=($AMOUNT_GENERATE_BUTTONS)
                 fi
                 # Для фикса битых #Time=
-                if [[ ! ${PW_GAME_TIME["$AMOUNT_GENERATE_BUTTONS"]} =~ [0-9]+ ]] ; then
+                if [[ ! ${PW_GAME_TIME["$AMOUNT_GENERATE_BUTTONS"]} =~ [0-9]+ ]] \
+                || (( ${PW_GAME_TIME["$AMOUNT_GENERATE_BUTTONS"]} >= 999999999 )) ; then
                     portwine_exe=${PW_NAME_D_ICON["$AMOUNT_GENERATE_BUTTONS"]//\"/}
                     search_desktop_file
                     unset portwine_exe
@@ -660,7 +661,8 @@ else
     if [[ $SORT_WITH_TIME == enabled ]] ; then
         for i in "${!PW_GAME_TIME[@]}" ; do
             for j in "${!PW_GAME_TIME[@]}" ; do
-                if (( ${PW_GAME_TIME[$i]} > ${PW_GAME_TIME[$j]} )) ; then
+                if (( ${PW_GAME_TIME[$i]} > ${PW_GAME_TIME[$j]} )) \
+                && [[ ! ${PW_AMOUNT_NEW_DESKTOP[*]} =~ $j ]] ; then
                     tmp_0=${PW_GAME_TIME[$i]}
                     tmp_1=${PW_ALL_DF[$i]}
                     tmp_2=${PW_NAME_D_ICON[$i]}


### PR DESCRIPTION
1) Фикс для NEW_DESKTOP. Смысл в том, чтобы новые ярлыки всегда отображались первый раз на самом вверху (потому что сортировка по времени их всегда будет вниз отправлять, и чтобы каждый раз их не искать, самый первое создание будет отправлять на самый вверх и последующем уже по времени). 
Сам pr, то что для этого всё сделано, но здесь недочёт )))
2) debug ломает таймер (потому что portwine_launcher в нём запускается в фоне), по этому когда дебаг, то таймер работать не будет. И то что таймер ломается, в time попадает очень большое число (свыше 10 тысяч дней), 10 тысяч дней это приблизительно 999999999 секунд, или 31 год. Наверное никто столько играть не будет во что-то одно, по этому добавил сброс счётчика в 0, если там такое число.