### PR TITLE
Improvements for name_desktop

### DIFF
--- a/data_from_portwine/locales/PortProton.pot
+++ b/data_from_portwine/locales/PortProton.pot
@@ -41,6 +41,10 @@ msgstr  ""
 msgid   "Newest DXVK, VKD3D, D8VK (Vulkan v1.3+)"
 msgstr  ""
 
+msgid   "A higher number of duplicate desktop files were found for this file."
+        "\\nShould I delete the extra ones or not?"
+msgstr  ""
+
 msgid   "Gallium Nine (DirectX 9 for MESA)"
 msgstr  ""
 

--- a/data_from_portwine/locales/es/LC_MESSAGES/PortProton.po
+++ b/data_from_portwine/locales/es/LC_MESSAGES/PortProton.po
@@ -1872,6 +1872,11 @@ msgstr "Agregar acceso directo a la biblioteca de STEAM"
 msgid "Name"
 msgstr "Nombre"
 
+msgid ""
+"A higher number of duplicate desktop files were found for this file."
+"\\nShould I delete the extra ones or not?"
+msgstr ""
+
 msgid "For adding shortcut to STEAM, needed restart.\\n\\nRestart STEAM now?"
 msgstr ""
 "Para agregar el acceso directo a STEAM, es necesario reiniciar.\\n\\¿Quieres "

--- a/data_from_portwine/locales/ru/LC_MESSAGES/PortProton.po
+++ b/data_from_portwine/locales/ru/LC_MESSAGES/PortProton.po
@@ -55,6 +55,13 @@ msgstr "Gallium Zink (трансляция OpenGL в Vulkan)"
 msgid "CREATE SHORTCUT"
 msgstr "СОЗДАТЬ ЯРЛЫК"
 
+msgid ""
+"A higher number of duplicate desktop files were found for this file."
+"\\nShould I delete the extra ones or not?"
+msgstr ""
+"Для этого файла было обнаружено большее количество дубликатов\\nфайлов "
+"рабочего стола. Удалить лишние или нет?"
+
 msgid "Create shortcut for select file..."
 msgstr "Создать ярлык для выбранного файла..."
 

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -875,6 +875,7 @@ search_desktop_file () {
 
 # Конвертация секунд в дни, часы, минуты
 seconds_to_time () {
+    [[ ! $DESKTOP_WITH_TIME == enabled ]] && return 0
     [[ -z $1 ]] && return 0
     local seconds days hours minutes
     seconds=$1
@@ -5434,22 +5435,9 @@ portwine_create_shortcut () {
     [[ -z "${PW_SHORTCUT_DESKTOP}" ]] && PW_SHORTCUT_DESKTOP="TRUE"
     [[ -z "${PW_SHORTCUT_STEAM}" ]] && PW_SHORTCUT_STEAM="FALSE"
 
-    unset name_desktop
-    search_desktop_file
-    if [[ -n ${DESKTOP_FILES_ARRAY[0]} ]] ; then
-        for df in "${DESKTOP_FILES_ARRAY[@]}" ; do
-            df="${df//"$PORT_WINE_PATH/"/}"
-            df="${df//.desktop/}"
-            if [[ ${PORTWINE_DB^^} =~ ${df^^} ]] && [[ ${PORTWINE_DB^^} != ${df^^} ]]
-            then name_desktop="$df"
-            fi
-        done
-    fi
-    if [[ -z $name_desktop ]] ; then
-        if [[ -n $PW_SHORTCUT_PROXY ]]
-        then name_desktop="$PW_SHORTCUT_PROXY"
-        else name_desktop="$PORTWINE_DB"
-        fi
+    if [[ -n $PW_SHORTCUT_PROXY ]]
+    then name_desktop="$PW_SHORTCUT_PROXY"
+    else name_desktop="$PORTWINE_DB"
     fi
     export name_desktop
 
@@ -5499,11 +5487,12 @@ portwine_create_shortcut () {
 
         edit_user_conf_from_gui PW_SHORTCUT_MENU PW_SHORTCUT_DESKTOP PW_SHORTCUT_STEAM
 
-        if [[ -n ${DESKTOP_FILES_ARRAY[0]} ]] && [[ $name_desktop != $df ]] || [[ -n ${DESKTOP_FILES_ARRAY[1]} ]] ; then
+        if [[ -n ${DESKTOP_FILES_ARRAY[0]} ]] && [[ $name_desktop != $DESKTOP_NAME_FILE ]] || [[ -n ${DESKTOP_FILES_ARRAY[1]} ]] ; then
             if yad_question "${translations[A higher number of duplicate desktop files were found for this file.\\nShould I delete the extra ones or not?]}" ; then
                 for rm in "${DESKTOP_FILES_ARRAY[@]}" ; do
                     rm -f "$rm"
                 done
+                name_desktop="$PW_SHORTCUT_PROXY"
             fi
         else
             try_remove_file "${PORT_WINE_PATH}/${name_desktop}.desktop"

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -810,33 +810,26 @@ search_desktop_file () {
                     sed -i "s|Exec=env \"$PORT_SCRIPTS_PATH/start.sh\"|Exec=flatpak run ru.linux_gaming.PortProton|" "$desktop_file"
                 fi
                 EXEC_DESKTOP_NEW=${EXEC_DESKTOP//\"/}
-                if [[ -n $TIME_CURRENT_PROXY ]] && [[ $portwine_exe == "$EXEC_DESKTOP_NEW" ]] ; then
-                    TIME_CURRENT=$TIME_CURRENT_PROXY
-                    TIME_CURRENT_ARRAY+=($TIME_CURRENT)
-                    # Если существует несколько .desktop файлов на один и тот же .exe файл,
-                    # то среди них время берётся из того .desktop файла, в котором проведено дольше времени
-                    # и данное время будет потом записываться во все .desktop файлы у которых общий .exe файл
-                    if [[ -n ${TIME_CURRENT_ARRAY[1]} ]] ; then
-                        for i in "${!TIME_CURRENT_ARRAY[@]}" ; do
-                            for j in "${!TIME_CURRENT_ARRAY[@]}" ; do
-                                if (( ${TIME_CURRENT_ARRAY[$i]} > ${TIME_CURRENT_ARRAY[$j]} )) ; then
-                                    tmp=${TIME_CURRENT_ARRAY[$i]}
-                                    TIME_CURRENT_ARRAY[i]=${TIME_CURRENT_ARRAY[$j]}
-                                    TIME_CURRENT_ARRAY[j]=$tmp
-                                fi
-                            done
-                        done
-                    fi
-                    TIME_CURRENT="${TIME_CURRENT_ARRAY[0]}"
-                fi
-                unset TIME_CURRENT_PROXY
                 if [[ $portwine_exe == "$EXEC_DESKTOP_NEW" ]] ; then
-                    # Когда новый .desktop файл
-                    if [[ $TIME_CURRENT == "" ]] ; then
-                        echo "#NEW_DESKTOP" >> "$desktop_file"
-                        TIME_CURRENT="0"
-                    # Для битых #Time=
-                    else
+                    if [[ -n $TIME_CURRENT_PROXY ]] ; then
+                        TIME_CURRENT=$TIME_CURRENT_PROXY
+                        TIME_CURRENT_ARRAY+=($TIME_CURRENT)
+                        # Если существует несколько .desktop файлов на один и тот же .exe файл,
+                        # то среди них время берётся из того .desktop файла, в котором проведено дольше времени
+                        # и данное время будет потом записываться во все .desktop файлы у которых общий .exe файл
+                        if [[ -n ${TIME_CURRENT_ARRAY[1]} ]] ; then
+                            for i in "${!TIME_CURRENT_ARRAY[@]}" ; do
+                                for j in "${!TIME_CURRENT_ARRAY[@]}" ; do
+                                    if (( ${TIME_CURRENT_ARRAY[$i]} > ${TIME_CURRENT_ARRAY[$j]} )) ; then
+                                        tmp=${TIME_CURRENT_ARRAY[$i]}
+                                        TIME_CURRENT_ARRAY[i]=${TIME_CURRENT_ARRAY[$j]}
+                                        TIME_CURRENT_ARRAY[j]=$tmp
+                                    fi
+                                done
+                            done
+                        fi
+                        TIME_CURRENT="${TIME_CURRENT_ARRAY[0]}"
+                        # Для битых #Time=
                         if [[ ! $TIME_CURRENT =~ [0-9]+ ]] \
                         || (( TIME_CURRENT >= 999999999 )) ; then
                             TIME_CURRENT="0"
@@ -845,10 +838,13 @@ search_desktop_file () {
                     DESKTOP_FILES_ARRAY["$count"]="$desktop_file"
                     (( count++ ))
                 fi
+                unset TIME_CURRENT_PROXY
             fi
         fi
     done
     IFS="$orig_IFS"
+
+    [[ -z $TIME_CURRENT ]] && TIME_CURRENT=0
     export TIME_CURRENT
 
     if [[ -n $PW_TIME_IN_GAME ]] ; then
@@ -5574,6 +5570,9 @@ portwine_create_shortcut () {
             fi
             unset PW_SKIP_RESTART_STEAM
         fi
+
+        # Когда новый .desktop файл
+        echo "#NEW_DESKTOP" >> "$PORT_WINE_PATH/$name_desktop.desktop"
 
         if [[ "$PW_NO_RESTART_PPDB" != "1" ]] ; then
             print_info "Restarting PP..."

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -38,6 +38,18 @@ print_wrapped () {
 }
 export -f print_wrapped
 
+make_abbreviation () {
+    local words new_word i
+    words=($1)
+    # Создаем новое слово, состоящее из начальных букв слов
+    new_word="${words[0]:0:1}"
+    for ((i=1 ; i<${#words[@]} ; i++)) ; do
+        new_word+="${words[$i]:0:1}"
+    done
+    echo "$new_word"
+}
+export -f make_abbreviation
+
 check_variables () { [[ -z ${!1} ]] && export $1="$2" ;}
 
 add_to_var () {
@@ -2304,25 +2316,25 @@ pw_create_gui_png () {
         export name_desktop_png="bat"
         return 0
     fi
-
     if [[ -z "$PORTPROTON_NAME" ]] \
+    || [[ -z "$FILE_DESCRIPTION" ]] \
     || [[ "$PW_NO_RESTART_PPDB" == "1" ]]
     then
         if [[ -n "${PORTWINE_CREATE_SHORTCUT_NAME}" ]] ; then
             PORTPROTON_NAME="${PORTWINE_CREATE_SHORTCUT_NAME}"
         else
             if command -v exiftool &>/dev/null ; then
-                if ! PW_PRODUCTNAME=$(timeout 3 exiftool -ProductName "${portwine_exe}" 2>/dev/null | sed -n 's/^Product Name\s*:\s*//p') ; then
+                if timeout 3 exiftool "$portwine_exe" &> "${PW_TMPFS_PATH}/exiftool.tmp" ; then
+                    PW_PRODUCTNAME=$(sed -n 's/^Product Name\s*:\s*//p' "${PW_TMPFS_PATH}/exiftool.tmp")
+                    FILE_DESCRIPTION=$(sed -n 's/^File Description\s*:\s*//p' "${PW_TMPFS_PATH}/exiftool.tmp")
+                else
                     print_error "exiftool - broken!"
-                    if [[ -n "$PW_DEBUG" ]] ; then
-                        debug_timer --start
-                        timeout 5 exiftool -ProductName "${portwine_exe}"
-                        debug_timer --end "exiftool"
-                    fi
                 fi
             else
                 print_warning "use portable exiftool"
-                PW_PRODUCTNAME=$(env PERL5LIB="${PW_PLUGINS_PATH}/portable/lib/perl5" "${PW_PLUGINS_PATH}/portable/bin/exiftool" -ProductName "${portwine_exe}" | sed -n 's/^Product Name\s*:\s*//p')
+                env PERL5LIB="${PW_PLUGINS_PATH}/portable/lib/perl5" "${PW_PLUGINS_PATH}/portable/bin/exiftool" "$portwine_exe" &> "${PW_TMPFS_PATH}/exiftool.tmp"
+                PW_PRODUCTNAME=$(sed -n 's/^Product Name\s*:\s*//p' "${PW_TMPFS_PATH}/exiftool.tmp")
+                FILE_DESCRIPTION=$(sed -n 's/^File Description\s*:\s*//p' "${PW_TMPFS_PATH}/exiftool.tmp")
             fi
 
             if [[ "$PW_PRODUCTNAME" =~ (Launcher|RU) ]]
@@ -2341,7 +2353,7 @@ pw_create_gui_png () {
 
         PORTPROTON_NAME="$(echo "${PORTPROTON_NAME}" | sed "s/\`//g" | sed "s/\"//g" | sed "s/'//g" | sed "s/\!//g")"
         export PORTPROTON_NAME
-        edit_db_from_gui PORTPROTON_NAME
+        edit_db_from_gui PORTPROTON_NAME FILE_DESCRIPTION
     fi
 
     resize_png "$portwine_exe" "${PORTPROTON_NAME}" "128"
@@ -5398,11 +5410,6 @@ resize_png () {
         && [[ "$ALPINE_FP" != "1" ]]
         then
             print_error "exe-thumbnailer - broken!"
-            if [[ -n "$PW_DEBUG" ]] ; then
-                debug_timer --start
-                timeout 5 exe-thumbnailer --force-resize -s "$RESIZE_TO" "$(readlink -f "${RESIZE_FILE}")" "${PORT_WINE_PATH}/data/img/${RESIZE_NAME_PNG}.png"
-                debug_timer --end "exe-thumbnailer"
-            fi
         fi
     else
         print_warning "use portable exe-thumbnailer"
@@ -5439,12 +5446,9 @@ portwine_create_shortcut () {
         done
     fi
     if [[ -z $name_desktop ]] ; then
-        if [[ ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB^^} ]] \
-        && [[ ${PORTPROTON_NAME^^} != "${PORTWINE_DB^^}" ]]
-        then
-            name_desktop="$PORTPROTON_NAME"
-        else
-            name_desktop="$PORTWINE_DB_NEW"
+        if [[ -n $PW_SHORTCUT_PROXY ]]
+        then name_desktop="$PW_SHORTCUT_PROXY"
+        else name_desktop="$PORTWINE_DB"
         fi
     fi
     export name_desktop
@@ -5622,11 +5626,6 @@ pw_auto_create_shortcut () {
                 link_cmd=$(sed -n 's/^Command Line Arguments\s*:\s*//p' "${PW_TMPFS_PATH}/exiftool.tmp")
             else
                 print_error "exiftool - broken!"
-                if [[ -n "$PW_DEBUG" ]] ; then
-                    debug_timer --start
-                    timeout 5 exiftool "$link_file"
-                    debug_timer --end "exiftool"
-                fi
             fi
         else
             print_warning "use portable exiftool"

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -786,7 +786,7 @@ debug_timer () {
 
 # Поиск нужного .desktop файла по $portwine_exe
 search_desktop_file () {
-    local count desktop_file desktop_file_new EXEC_DESKTOP EXEC_DESKTOP_NEW TIME_TOTAL i j
+    local count desktop_file desktop_file_new EXEC_DESKTOP TIME_CURRENT_PROXY EXEC_DESKTOP_NEW TIME_TOTAL i j
     unset TIME_CURRENT_ARRAY DESKTOP_FILES_ARRAY
     count=0
     for desktop_file in "$PORT_WINE_PATH"/* ; do
@@ -800,12 +800,36 @@ search_desktop_file () {
                         else
                             EXEC_DESKTOP=${line//Exec=env \"$PORT_SCRIPTS_PATH\/start.sh\" /}
                         fi
-                        EXEC_DESKTOP_NEW=${EXEC_DESKTOP//\"/}
                     fi
-                    if [[ $line =~ ^#Time= ]] && [[ $portwine_exe == "$EXEC_DESKTOP_NEW" ]] ; then
-                        TIME_CURRENT=${line//#Time=/}
-                    fi
+                    [[ $line =~ ^#Time= ]] && TIME_CURRENT_PROXY=${line//#Time=/}
                 done < "$desktop_file"
+                # Для конвертации существующих .desktop файлов flatpak в натив и наоборот
+                if [[ $EXEC_DESKTOP =~ ^"Exec=flatpak run ru.linux_gaming.PortProton " ]] ; then
+                    sed -i "s|Exec=flatpak run ru.linux_gaming.PortProton|Exec=env \"$PORT_SCRIPTS_PATH/start.sh\"|" "$desktop_file"
+                elif [[ $EXEC_DESKTOP =~ ^"Exec=env \"$PORT_SCRIPTS_PATH/start.sh\" " ]] ; then
+                    sed -i "s|Exec=env \"$PORT_SCRIPTS_PATH/start.sh\"|Exec=flatpak run ru.linux_gaming.PortProton|" "$desktop_file"
+                fi
+                EXEC_DESKTOP_NEW=${EXEC_DESKTOP//\"/}
+                if [[ -n $TIME_CURRENT_PROXY ]] && [[ $portwine_exe == "$EXEC_DESKTOP_NEW" ]] ; then
+                    TIME_CURRENT=$TIME_CURRENT_PROXY
+                    TIME_CURRENT_ARRAY+=($TIME_CURRENT)
+                    # Если существует несколько .desktop файлов на один и тот же .exe файл,
+                    # то среди них время берётся из того .desktop файла, в котором проведено дольше времени
+                    # и данное время будет потом записываться во все .desktop файлы у которых общий .exe файл
+                    if [[ -n ${TIME_CURRENT_ARRAY[1]} ]] ; then
+                        for i in "${!TIME_CURRENT_ARRAY[@]}" ; do
+                            for j in "${!TIME_CURRENT_ARRAY[@]}" ; do
+                                if (( ${TIME_CURRENT_ARRAY[$i]} > ${TIME_CURRENT_ARRAY[$j]} )) ; then
+                                    tmp=${TIME_CURRENT_ARRAY[$i]}
+                                    TIME_CURRENT_ARRAY[i]=${TIME_CURRENT_ARRAY[$j]}
+                                    TIME_CURRENT_ARRAY[j]=$tmp
+                                fi
+                            done
+                        done
+                    fi
+                    TIME_CURRENT="${TIME_CURRENT_ARRAY[0]}"
+                fi
+                unset TIME_CURRENT_PROXY
                 if [[ $portwine_exe == "$EXEC_DESKTOP_NEW" ]] ; then
                     # Когда новый .desktop файл
                     if [[ $TIME_CURRENT == "" ]] ; then
@@ -814,12 +838,10 @@ search_desktop_file () {
                     # Для битых #Time=
                     else
                         if [[ ! $TIME_CURRENT =~ [0-9]+ ]] \
-                        || (( $TIME_CURRENT >= 999999999 )) ; then
+                        || (( TIME_CURRENT >= 999999999 )) ; then
                             TIME_CURRENT="0"
                         fi
                     fi
-                    TIME_CURRENT_ARRAY+=($TIME_CURRENT)
-                    unset TIME_CURRENT
                     DESKTOP_FILES_ARRAY["$count"]="$desktop_file"
                     (( count++ ))
                 fi
@@ -827,23 +849,8 @@ search_desktop_file () {
         fi
     done
     IFS="$orig_IFS"
+    export TIME_CURRENT
 
-    # Если существуют .desktop файлы на один и тот же .exe файл, то среди них выбирается
-    # текущее время берётся из того .desktop файла, в котором проведено больше времени
-    # и запись этого большего времени будет потом записываться во все .desktop файлы
-    # у которых общий .exe файл, это нужно для того, чтобы в главном меню .desktop файлы
-    # упорядочивались нормально.
-    for i in "${!TIME_CURRENT_ARRAY[@]}" ; do
-        for j in "${!TIME_CURRENT_ARRAY[@]}" ; do
-            if (( ${TIME_CURRENT_ARRAY[$i]} > ${TIME_CURRENT_ARRAY[$j]} )) ; then
-                tmp=${TIME_CURRENT_ARRAY[$i]}
-                TIME_CURRENT_ARRAY[i]=${TIME_CURRENT_ARRAY[$j]}
-                TIME_CURRENT_ARRAY[j]=$tmp
-            fi
-        done
-    done
-
-    TIME_CURRENT="${TIME_CURRENT_ARRAY[0]}"
     if [[ -n $PW_TIME_IN_GAME ]] ; then
         TIME_TOTAL=$(( TIME_CURRENT + PW_TIME_IN_GAME ))
         for df in "${DESKTOP_FILES_ARRAY[@]}" ; do

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -873,6 +873,73 @@ search_desktop_file () {
     fi
 }
 
+create_pw_comment () {
+    search_desktop_file
+    unset DESKTOP_NAME_FILE PW_SHORTCUT_PROXY
+    if [[ -n ${DESKTOP_FILES_ARRAY[0]} ]] ; then
+        for df in "${DESKTOP_FILES_ARRAY[@]}" ; do
+            df="${df//"$PORT_WINE_PATH/"/}"
+            DESKTOP_NAME_FILE="${df//.desktop/}"
+        done
+    fi
+    if [[ -z "${PW_COMMENT_DB}" ]] ; then
+        [[ $FILE_DESCRIPTION != "" ]] && FILE_DESCRIPTION_ABBR=$(make_abbreviation "$FILE_DESCRIPTION")
+        [[ $PORTPROTON_NAME != "" ]] && PORTPROTON_NAME_ABBR=$(make_abbreviation "$PORTPROTON_NAME")
+        if [[ -n $DESKTOP_NAME_FILE ]] && [[ $DESKTOP_NAME_FILE != "" ]] ; then
+            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$DESKTOP_NAME_FILE" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+            PW_SHORTCUT_PROXY="$DESKTOP_NAME_FILE"
+        elif [[ ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB^^} ]] && [[ ${PORTPROTON_NAME^^} != "${PORTWINE_DB^^}" ]] ; then
+            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTPROTON_NAME" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+            PW_SHORTCUT_PROXY="$PORTPROTON_NAME"
+        elif (( ${#PORTPROTON_NAME_ABBR} > 2 )) && [[ ${PORTPROTON_NAME_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
+            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTPROTON_NAME" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+            PW_SHORTCUT_PROXY="$PORTPROTON_NAME"
+        elif [[ ${FILE_DESCRIPTION^^} =~ ${PORTWINE_DB^^} ]] && [[ ${FILE_DESCRIPTION^^} != "${PORTWINE_DB^^}" ]] ; then
+            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$FILE_DESCRIPTION" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+            PW_SHORTCUT_PROXY="$FILE_DESCRIPTION"
+        elif (( ${#FILE_DESCRIPTION_ABBR} > 2 )) && [[ ${FILE_DESCRIPTION_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
+            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$FILE_DESCRIPTION" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+            PW_SHORTCUT_PROXY="$FILE_DESCRIPTION"
+        else
+            unset PORTWINE_DB_PROXY PORTWINE_DB_NEW
+            PORTWINE_DB="${PORTWINE_DB//_/ }"
+            if [[ ${PORTWINE_DB:0:1} =~ [a-z] ]] ; then
+                PORTWINE_DB_UPPER="${PORTWINE_DB^^}"
+                PORTWINE_DB="${PORTWINE_DB_UPPER:0:1}${PORTWINE_DB:1}"
+            fi
+            if (( ${#PORTWINE_DB} > 3 )) ; then
+                for ((i=0 ; i<${#PORTWINE_DB} ; i++)) ; do
+                    if [[ ${PORTWINE_DB:i:2} =~ ([a-z][A-Z]|[a-z][0-9]) ]] \
+                    && [[ ! ${PORTWINE_DB:i:3} =~ ([a-z][A-Z]" "|[a-z][0-9]" ") ]] ; then
+                        PORTWINE_DB_PROXY+="${PORTWINE_DB:i:1} "
+                    elif [[ ${PORTWINE_DB:i:3} =~ [0-9][0-9][a-zA-Z] ]] ; then
+                        PORTWINE_DB_PROXY+="${PORTWINE_DB:i:2} "
+                        ((i++))
+                    else
+                        PORTWINE_DB_PROXY+="${PORTWINE_DB:i:1}"
+                    fi
+                done
+                for ((i=0 ; i<${#PORTWINE_DB_PROXY} ; i++)) ; do
+                    if [[ ${PORTWINE_DB_PROXY:i:2} =~ " "[a-z] ]] ; then
+                        PORTWINE_DB_UPPER="${PORTWINE_DB_PROXY:i:2}"
+                        PORTWINE_DB_NEW+="${PORTWINE_DB_UPPER^^}"
+                        ((i++))
+                    else
+                        PORTWINE_DB_NEW+="${PORTWINE_DB_PROXY:i:1}"
+                    fi
+                done
+            else
+                PORTWINE_DB_NEW="$PORTWINE_DB"
+            fi
+            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTWINE_DB_NEW" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+            PW_SHORTCUT_PROXY="$PORTWINE_DB_NEW"
+        fi
+    else
+        PW_COMMENT_DB="$PW_COMMENT_DB$(seconds_to_time "$TIME_CURRENT")"
+        PW_SHORTCUT_PROXY="$DESKTOP_NAME_FILE"
+    fi
+}
+
 # Конвертация секунд в дни, часы, минуты
 seconds_to_time () {
     [[ ! $DESKTOP_WITH_TIME == enabled ]] && return 0
@@ -5435,11 +5502,7 @@ portwine_create_shortcut () {
     [[ -z "${PW_SHORTCUT_DESKTOP}" ]] && PW_SHORTCUT_DESKTOP="TRUE"
     [[ -z "${PW_SHORTCUT_STEAM}" ]] && PW_SHORTCUT_STEAM="FALSE"
 
-    if [[ -n $PW_SHORTCUT_PROXY ]]
-    then name_desktop="$PW_SHORTCUT_PROXY"
-    else name_desktop="$PORTWINE_DB"
-    fi
-    export name_desktop
+    [[ -z $PW_SHORTCUT_PROXY ]] && create_pw_comment && export name_desktop="$PW_SHORTCUT_PROXY"
 
     [[ -z "${name_desktop_png}" ]] && name_desktop_png="${PORTPROTON_NAME// /_}"
 
@@ -5492,7 +5555,7 @@ portwine_create_shortcut () {
                 for rm in "${DESKTOP_FILES_ARRAY[@]}" ; do
                     rm -f "$rm"
                 done
-                name_desktop="$PW_SHORTCUT_PROXY"
+                [[ $name_desktop == "" ]] && create_pw_comment && export name_desktop="$PW_SHORTCUT_PROXY"
             fi
         else
             try_remove_file "${PORT_WINE_PATH}/${name_desktop}.desktop"

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -786,7 +786,7 @@ debug_timer () {
 
 # Поиск нужного .desktop файла по $portwine_exe
 search_desktop_file () {
-    local count desktop_file desktop_file_new EXEC_DESKTOP EXEC_DESKTOP_NEW TIME_TOTAL i j df
+    local count desktop_file desktop_file_new EXEC_DESKTOP EXEC_DESKTOP_NEW TIME_TOTAL i j
     unset TIME_CURRENT_ARRAY DESKTOP_FILES_ARRAY
     count=0
     for desktop_file in "$PORT_WINE_PATH"/* ; do
@@ -5424,10 +5424,26 @@ portwine_create_shortcut () {
     [[ -z "${PW_SHORTCUT_DESKTOP}" ]] && PW_SHORTCUT_DESKTOP="TRUE"
     [[ -z "${PW_SHORTCUT_STEAM}" ]] && PW_SHORTCUT_STEAM="FALSE"
 
-    if [[ -z "${PORTPROTON_NAME}" ]] ; then
-        name_desktop="$(basename "$portwine_exe")"
+    name_desktop_basename="$(basename "${portwine_exe//.exe/}")"
+    search_desktop_file
+    if [[ -n $df ]] ; then
+        name_desktop_df="${df//"$PORT_WINE_PATH/"/}"
+        name_desktop_df="${name_desktop_df//.desktop/}"
+        if [[ $(echo "$name_desktop_basename" | tr '[:lower:]' '[:upper:]') =~ $(echo "$name_desktop_df" | tr '[:lower:]' '[:upper:]') ]]
+        then
+            name_desktop="$name_desktop_df"
+        elif [[ -n $PORTPROTON_NAME ]] && [[ ${DESKTOP_FILES_ARRAY[*]} =~ $PORTPROTON_NAME ]]
+        then
+            name_desktop="$PORTPROTON_NAME"
+        else
+            name_desktop="$name_desktop_df"
+        fi
     else
-        name_desktop="${PORTPROTON_NAME}"
+        if [[ -z $PORTPROTON_NAME ]] ; then
+            name_desktop="$name_desktop_basename"
+        else
+            name_desktop="$PORTPROTON_NAME"
+        fi
     fi
     export name_desktop
 
@@ -5477,7 +5493,15 @@ portwine_create_shortcut () {
 
         edit_user_conf_from_gui PW_SHORTCUT_MENU PW_SHORTCUT_DESKTOP PW_SHORTCUT_STEAM
 
-        try_remove_file "${PORT_WINE_PATH}/${name_desktop}.desktop"
+        if [[ -n ${DESKTOP_FILES_ARRAY[1]} ]] ; then
+            if yad_question "${translations[A higher number of duplicate desktop files were found for this file.\\nShould I delete the extra ones or not?]}" ; then
+                for rm in "${DESKTOP_FILES_ARRAY[@]}" ; do
+                    rm -f "$rm"
+                done
+            fi
+        else
+            try_remove_file "${PORT_WINE_PATH}/${name_desktop}.desktop"
+        fi
 
         echo "[Desktop Entry]" > "${PORT_WINE_PATH}/${name_desktop}.desktop"
         echo "Name=${name_desktop}" >> "${PORT_WINE_PATH}/${name_desktop}.desktop"

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -786,7 +786,7 @@ debug_timer () {
 
 # Поиск нужного .desktop файла по $portwine_exe
 search_desktop_file () {
-    local count desktop_file desktop_file_new EXEC_DESKTOP TIME_CURRENT_PROXY EXEC_DESKTOP_NEW TIME_TOTAL i j
+    local count desktop_file desktop_file_new EXEC_DESKTOP TIME_CURRENT_PROXY EXEC_DESKTOP_NEW TIME_TOTAL i j df
     unset TIME_CURRENT_ARRAY DESKTOP_FILES_ARRAY
     count=0
     for desktop_file in "$PORT_WINE_PATH"/* ; do
@@ -5427,25 +5427,21 @@ portwine_create_shortcut () {
     [[ -z "${PW_SHORTCUT_DESKTOP}" ]] && PW_SHORTCUT_DESKTOP="TRUE"
     [[ -z "${PW_SHORTCUT_STEAM}" ]] && PW_SHORTCUT_STEAM="FALSE"
 
-    name_desktop_basename="$(basename "${portwine_exe//.exe/}")"
+    unset name_desktop
     search_desktop_file
-    if [[ -n $df ]] ; then
-        name_desktop_df="${df//"$PORT_WINE_PATH/"/}"
-        name_desktop_df="${name_desktop_df//.desktop/}"
-        if [[ $(echo "$name_desktop_basename" | tr '[:lower:]' '[:upper:]') =~ $(echo "$name_desktop_df" | tr '[:lower:]' '[:upper:]') ]]
-        then
-            name_desktop="$name_desktop_df"
-        elif [[ -n $PORTPROTON_NAME ]] && [[ ${DESKTOP_FILES_ARRAY[*]} =~ $PORTPROTON_NAME ]]
-        then
-            name_desktop="$PORTPROTON_NAME"
-        else
-            name_desktop="$name_desktop_df"
-        fi
-    else
-        if [[ -z $PORTPROTON_NAME ]] ; then
-            name_desktop="$name_desktop_basename"
-        else
-            name_desktop="$PORTPROTON_NAME"
+    if [[ -n ${DESKTOP_FILES_ARRAY[0]} ]] ; then
+        for df in "${DESKTOP_FILES_ARRAY[@]}" ; do
+            df="${df//"$PORT_WINE_PATH/"/}"
+            df="${df//.desktop/}"
+            if [[ ${PORTWINE_DB^^} =~ ${df^^} ]]
+            then name_desktop="$df"
+            fi
+        done
+    fi
+    if [[ -z $name_desktop ]] ; then
+        if [[ -n $PORTPROTON_NAME ]]
+        then name_desktop="$PORTPROTON_NAME"
+        else name_desktop="$PORTWINE_DB"
         fi
     fi
     export name_desktop

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -5433,15 +5433,18 @@ portwine_create_shortcut () {
         for df in "${DESKTOP_FILES_ARRAY[@]}" ; do
             df="${df//"$PORT_WINE_PATH/"/}"
             df="${df//.desktop/}"
-            if [[ ${PORTWINE_DB^^} =~ ${df^^} ]]
+            if [[ ${PORTWINE_DB^^} =~ ${df^^} ]] && [[ ${PORTWINE_DB^^} != ${df^^} ]]
             then name_desktop="$df"
             fi
         done
     fi
     if [[ -z $name_desktop ]] ; then
-        if [[ -n $PORTPROTON_NAME ]]
-        then name_desktop="$PORTPROTON_NAME"
-        else name_desktop="$PORTWINE_DB"
+        if [[ ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB^^} ]] \
+        && [[ ${PORTPROTON_NAME^^} != "${PORTWINE_DB^^}" ]]
+        then
+            name_desktop="$PORTPROTON_NAME"
+        else
+            name_desktop="$PORTWINE_DB_NEW"
         fi
     fi
     export name_desktop
@@ -5492,7 +5495,7 @@ portwine_create_shortcut () {
 
         edit_user_conf_from_gui PW_SHORTCUT_MENU PW_SHORTCUT_DESKTOP PW_SHORTCUT_STEAM
 
-        if [[ -n ${DESKTOP_FILES_ARRAY[1]} ]] ; then
+        if [[ -n ${DESKTOP_FILES_ARRAY[0]} ]] && [[ $name_desktop != $df ]] || [[ -n ${DESKTOP_FILES_ARRAY[1]} ]] ; then
             if yad_question "${translations[A higher number of duplicate desktop files were found for this file.\\nShould I delete the extra ones or not?]}" ; then
                 for rm in "${DESKTOP_FILES_ARRAY[@]}" ; do
                     rm -f "$rm"

--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -643,6 +643,14 @@ else
                 else
                     PW_AMOUNT_OLD_DESKTOP+=($AMOUNT_GENERATE_BUTTONS)
                 fi
+                # Для конвертация .desktop файлов flatpak в натив и наоборот
+                if [[ ${PW_NAME_D_ICON["$AMOUNT_GENERATE_BUTTONS"]} =~ ^"Exec=flatpak run ru.linux_gaming.PortProton " ]] ; then
+                    PW_NAME_D_ICON["$AMOUNT_GENERATE_BUTTONS"]=${PW_NAME_D_ICON["$AMOUNT_GENERATE_BUTTONS"]//Exec=flatpak run ru.linux_gaming.PortProton /}
+                    search_desktop_file
+                elif [[ ${PW_NAME_D_ICON["$AMOUNT_GENERATE_BUTTONS"]} =~ ^"Exec=env \"$PORT_SCRIPTS_PATH/start.sh\" " ]] ; then
+                    PW_NAME_D_ICON["$AMOUNT_GENERATE_BUTTONS"]=${PW_NAME_D_ICON["$AMOUNT_GENERATE_BUTTONS"]//Exec=env \"$PORT_SCRIPTS_PATH\/start.sh\" /}
+                    search_desktop_file
+                fi
                 # Для фикса битых #Time=
                 if [[ ! ${PW_GAME_TIME["$AMOUNT_GENERATE_BUTTONS"]} =~ [0-9]+ ]] \
                 || (( ${PW_GAME_TIME["$AMOUNT_GENERATE_BUTTONS"]} >= 999999999 )) ; then
@@ -658,7 +666,7 @@ else
 
     # Переопределение элементов в массивах в зависимости от PW_GAME_TIME, от большего значения к меньшему.
     # 10 миллисекунд на 40 .desktop файлов, работает быстро
-    if [[ $SORT_WITH_TIME == enabled ]] ; then
+    if [[ $SORT_WITH_TIME == enabled ]] && [[ -n ${PW_GAME_TIME[1]} ]] ; then
         for i in "${!PW_GAME_TIME[@]}" ; do
             for j in "${!PW_GAME_TIME[@]}" ; do
                 if (( ${PW_GAME_TIME[$i]} > ${PW_GAME_TIME[$j]} )) \

--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -636,10 +636,10 @@ else
                     [[ $line =~ ^#NEW_DESKTOP ]] && NEW_DESKTOP=1
                 done < "$desktop_file"
                 PW_ALL_DF["$AMOUNT_GENERATE_BUTTONS"]="$desktop_file_new"
-                if [[ $NEW_DESKTOP == 1 ]] && [[ $SORT_WITH_TIME == enabled ]] ; then
+                if [[ $SORT_WITH_TIME == enabled ]] && [[ $NEW_DESKTOP == 1 ]] ; then
                     unset NEW_DESKTOP
                     sed -i '/^#NEW_DESKTOP/d' "$desktop_file"
-                    PW_AMOUNT_NEW_DESKTOP+=($AMOUNT_GENERATE_BUTTONS)
+                    PW_AMOUNT_NEW_DESKTOP=($AMOUNT_GENERATE_BUTTONS)
                 else
                     PW_AMOUNT_OLD_DESKTOP+=($AMOUNT_GENERATE_BUTTONS)
                 fi
@@ -657,7 +657,7 @@ else
                     portwine_exe=${PW_NAME_D_ICON["$AMOUNT_GENERATE_BUTTONS"]//\"/}
                     search_desktop_file
                     unset portwine_exe
-                    PW_GAME_TIME["$AMOUNT_GENERATE_BUTTONS"]=${TIME_CURRENT_ARRAY[0]}
+                    PW_GAME_TIME["$AMOUNT_GENERATE_BUTTONS"]=$TIME_CURRENT
                 fi
                 (( AMOUNT_GENERATE_BUTTONS++ ))
             fi
@@ -667,10 +667,9 @@ else
     # Переопределение элементов в массивах в зависимости от PW_GAME_TIME, от большего значения к меньшему.
     # 10 миллисекунд на 40 .desktop файлов, работает быстро
     if [[ $SORT_WITH_TIME == enabled ]] && [[ -n ${PW_GAME_TIME[1]} ]] ; then
-        for i in "${!PW_GAME_TIME[@]}" ; do
-            for j in "${!PW_GAME_TIME[@]}" ; do
-                if (( ${PW_GAME_TIME[$i]} > ${PW_GAME_TIME[$j]} )) \
-                && [[ ! ${PW_AMOUNT_NEW_DESKTOP[*]} =~ $j ]] ; then
+        for i in "${PW_AMOUNT_OLD_DESKTOP[@]}" ; do
+            for j in "${PW_AMOUNT_OLD_DESKTOP[@]}" ; do
+                if (( ${PW_GAME_TIME[$i]} > ${PW_GAME_TIME[$j]} )) ; then
                     tmp_0=${PW_GAME_TIME[$i]}
                     tmp_1=${PW_ALL_DF[$i]}
                     tmp_2=${PW_NAME_D_ICON[$i]}
@@ -693,7 +692,7 @@ else
     # Генерация .desktop баттанов для главного меню
     IFS=$'\n'
     PW_GENERATE_BUTTONS="--field=   ${translations[Create shortcut...]}!${PW_GUI_ICON_PATH}/find_48.svg!:FBTNR%@bash -c \"button_click --normal pw_find_exe\"%"
-    for dp in ${PW_AMOUNT_NEW_DESKTOP[@]} ${PW_AMOUNT_OLD_DESKTOP[@]} ; do
+    for dp in "${PW_AMOUNT_NEW_DESKTOP[@]}" "${PW_AMOUNT_OLD_DESKTOP[@]}" ; do
         PW_NAME_D_ICON_48="${PW_ICON_PATH[dp]%.png}_48"
         PW_NAME_D_ICON_128="${PW_ICON_PATH[dp]%.png}"
         PW_NAME_D_ICON_NEW="${PW_NAME_D_ICON[dp]//\"/}"
@@ -733,7 +732,6 @@ else
     --gui-type-layout="${MAIN_MENU_GUI_TYPE_LAYOUT}" \
     --align-buttons --scroll --separator=" " ${PW_GENERATE_BUTTONS} 2>/dev/null &
     IFS="$orig_IFS"
-    unset PW_GENERATE_BUTTONS
 
     "${pw_yad}" --plug=$KEY_MENU --tabnum="${PW_GUI_SORT_TABS[3]}" --form --columns=3 --align-buttons --separator=";" --homogeneous-column \
     --gui-type-layout="${MAIN_MENU_GUI_TYPE_LAYOUT}" \

--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -500,70 +500,7 @@ if [[ -f "${portwine_exe}" ]] ; then
             PW_SHORTCUT="${translations[DELETE SHORTCUT]}!$PW_GUI_ICON_PATH/$BUTTON_SIZE.png!${translations[Delete shortcut for select file...]}:98"
         fi
 
-        search_desktop_file
-        unset DESKTOP_NAME_FILE PW_SHORTCUT_PROXY
-        if [[ -n ${DESKTOP_FILES_ARRAY[0]} ]] ; then
-            for df in "${DESKTOP_FILES_ARRAY[@]}" ; do
-                df="${df//"$PORT_WINE_PATH/"/}"
-                DESKTOP_NAME_FILE="${df//.desktop/}"
-            done
-        fi
-        if [[ -z "${PW_COMMENT_DB}" ]] ; then
-            [[ $FILE_DESCRIPTION != "" ]] && FILE_DESCRIPTION_ABBR=$(make_abbreviation "$FILE_DESCRIPTION")
-            [[ $PORTPROTON_NAME != "" ]] && PORTPROTON_NAME_ABBR=$(make_abbreviation "$PORTPROTON_NAME")
-            if [[ -n $DESKTOP_NAME_FILE ]] && [[ $DESKTOP_NAME_FILE != "" ]] ; then
-                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$DESKTOP_NAME_FILE" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
-                PW_SHORTCUT_PROXY="$DESKTOP_NAME_FILE"
-            elif [[ ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB^^} ]] && [[ ${PORTPROTON_NAME^^} != "${PORTWINE_DB^^}" ]] ; then
-                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTPROTON_NAME" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
-                PW_SHORTCUT_PROXY="$PORTPROTON_NAME"
-            elif (( ${#PORTPROTON_NAME_ABBR} > 2 )) && [[ ${PORTPROTON_NAME_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
-                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTPROTON_NAME" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
-                PW_SHORTCUT_PROXY="$PORTPROTON_NAME"
-            elif [[ ${FILE_DESCRIPTION^^} =~ ${PORTWINE_DB^^} ]] && [[ ${FILE_DESCRIPTION^^} != "${PORTWINE_DB^^}" ]] ; then
-                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$FILE_DESCRIPTION" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
-                PW_SHORTCUT_PROXY="$FILE_DESCRIPTION"
-            elif (( ${#FILE_DESCRIPTION_ABBR} > 2 )) && [[ ${FILE_DESCRIPTION_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
-                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$FILE_DESCRIPTION" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
-                PW_SHORTCUT_PROXY="$FILE_DESCRIPTION"
-            else
-                unset PORTWINE_DB_PROXY PORTWINE_DB_NEW
-                PORTWINE_DB="${PORTWINE_DB//_/ }"
-                if [[ ${PORTWINE_DB:0:1} =~ [a-z] ]] ; then
-                    PORTWINE_DB_UPPER="${PORTWINE_DB^^}"
-                    PORTWINE_DB="${PORTWINE_DB_UPPER:0:1}${PORTWINE_DB:1}"
-                fi
-                if (( ${#PORTWINE_DB} > 3 )) ; then
-                    for ((i=0 ; i<${#PORTWINE_DB} ; i++)) ; do
-                        if [[ ${PORTWINE_DB:i:2} =~ ([a-z][A-Z]|[a-z][0-9]) ]] \
-                        && [[ ! ${PORTWINE_DB:i:3} =~ ([a-z][A-Z]" "|[a-z][0-9]" ") ]] ; then
-                            PORTWINE_DB_PROXY+="${PORTWINE_DB:i:1} "
-                        elif [[ ${PORTWINE_DB:i:3} =~ [0-9][0-9][a-zA-Z] ]] ; then
-                            PORTWINE_DB_PROXY+="${PORTWINE_DB:i:2} "
-                            ((i++))
-                        else
-                            PORTWINE_DB_PROXY+="${PORTWINE_DB:i:1}"
-                        fi
-                    done
-                    for ((i=0 ; i<${#PORTWINE_DB_PROXY} ; i++)) ; do
-                        if [[ ${PORTWINE_DB_PROXY:i:2} =~ " "[a-z] ]] ; then
-                            PORTWINE_DB_UPPER="${PORTWINE_DB_PROXY:i:2}"
-                            PORTWINE_DB_NEW+="${PORTWINE_DB_UPPER^^}"
-                            ((i++))
-                        else
-                            PORTWINE_DB_NEW+="${PORTWINE_DB_PROXY:i:1}"
-                        fi
-                    done
-                else
-                    PORTWINE_DB_NEW="$PORTWINE_DB"
-                fi
-                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTWINE_DB_NEW" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
-                PW_SHORTCUT_PROXY="$PORTWINE_DB_NEW"
-            fi
-        else
-            PW_COMMENT_DB="$PW_COMMENT_DB$(seconds_to_time "$TIME_CURRENT")"
-            PW_SHORTCUT_PROXY="$DESKTOP_NAME_FILE"
-        fi
+        create_pw_comment
 
         export KEY_START="$RANDOM"
         if [[ "${PW_GUI_START}" == "NOTEBOOK" ]] ; then

--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -96,9 +96,7 @@ unset CHK_SYMLINK_FILE PW_MESA_GL_VERSION_OVERRIDE PW_VKD3D_FEATURE_LEVEL PATH_T
 unset PW_PREFIX_NAME WINEPREFIX VULKAN_MOD PW_WINE_VER PW_ADD_TO_ARGS_IN_RUNTIME PW_GAMEMODERUN_SLR AMD_VULKAN_ICD PW_WINE_CPU_TOPOLOGY
 unset MANGOHUD_CONFIG FPS_LIMIT PW_WINE_USE WINEDLLPATH WINE WINEDIR WINELOADER WINESERVER PW_USE_RUNTIME PORTWINE_CREATE_SHORTCUT_NAME MIRROR
 unset PW_LOCALE_SELECT PW_SETTINGS_INDICATION PW_GUI_START PW_AUTOINSTALL_EXE NOSTSTDIR RADV_DEBUG PW_NO_AUTO_CREATE_SHORTCUT
-unset PW_NAME_D_ICON PW_ICON_PATH PW_GAME_TIME PW_ALL_DF PW_AMOUNT_NEW_DESKTOP PW_AMOUNT_OLD_DESKTOP PW_DESKTOP_FILES
-unset AI_TYPE AI_NAME AI_IMAGE AI_INFO AI_FILE_ARRAY AI_TRUE_FILE AI_FILE_UNSORTED AI_FILE_SORTED PW_GENERATE_BUTTONS
-unset PW_DESKTOP_FILES_REGEX PW_TERM PW_EXEC_FROM_DESKTOP
+unset PW_TERM PW_EXEC_FROM_DESKTOP
 
 export PORT_WINE_TMP_PATH="${PORT_WINE_PATH}/data/tmp"
 rm -f "$PORT_WINE_TMP_PATH"/*{exe,msi,tar}*
@@ -617,6 +615,8 @@ else
         gui_userconf
     fi
 
+    unset PW_NAME_D_ICON PW_ICON_PATH PW_GAME_TIME PW_ALL_DF PW_AMOUNT_NEW_DESKTOP PW_AMOUNT_OLD_DESKTOP PW_DESKTOP_FILES
+    unset AI_TYPE AI_NAME AI_IMAGE AI_INFO AI_FILE_ARRAY AI_TRUE_FILE AI_FILE_UNSORTED AI_FILE_SORTED PW_DESKTOP_FILES_REGEX
     # Поиск .desktop файлов
     AMOUNT_GENERATE_BUTTONS="0"
     for desktop_file in "$PORT_WINE_PATH"/* ; do
@@ -646,17 +646,19 @@ else
                 # Для конвертация .desktop файлов flatpak в натив и наоборот
                 if [[ ${PW_NAME_D_ICON["$AMOUNT_GENERATE_BUTTONS"]} =~ ^"Exec=flatpak run ru.linux_gaming.PortProton " ]] ; then
                     PW_NAME_D_ICON["$AMOUNT_GENERATE_BUTTONS"]=${PW_NAME_D_ICON["$AMOUNT_GENERATE_BUTTONS"]//Exec=flatpak run ru.linux_gaming.PortProton /}
-                    search_desktop_file
+                    NEED_FIXES_DESKTOP=1
                 elif [[ ${PW_NAME_D_ICON["$AMOUNT_GENERATE_BUTTONS"]} =~ ^"Exec=env \"$PORT_SCRIPTS_PATH/start.sh\" " ]] ; then
                     PW_NAME_D_ICON["$AMOUNT_GENERATE_BUTTONS"]=${PW_NAME_D_ICON["$AMOUNT_GENERATE_BUTTONS"]//Exec=env \"$PORT_SCRIPTS_PATH\/start.sh\" /}
-                    search_desktop_file
+                    NEED_FIXES_DESKTOP=1
                 fi
                 # Для фикса битых #Time=
                 if [[ ! ${PW_GAME_TIME["$AMOUNT_GENERATE_BUTTONS"]} =~ [0-9]+ ]] \
-                || (( ${PW_GAME_TIME["$AMOUNT_GENERATE_BUTTONS"]} >= 999999999 )) ; then
+                || (( ${PW_GAME_TIME["$AMOUNT_GENERATE_BUTTONS"]} >= 999999999 )) \
+                || [[ $NEED_FIXES_DESKTOP == 1 ]]
+                then
                     portwine_exe=${PW_NAME_D_ICON["$AMOUNT_GENERATE_BUTTONS"]//\"/}
                     search_desktop_file
-                    unset portwine_exe
+                    unset portwine_exe NEED_FIXES_DESKTOP
                     PW_GAME_TIME["$AMOUNT_GENERATE_BUTTONS"]=$TIME_CURRENT
                 fi
                 (( AMOUNT_GENERATE_BUTTONS++ ))

--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -500,17 +500,30 @@ if [[ -f "${portwine_exe}" ]] ; then
             PW_SHORTCUT="${translations[DELETE SHORTCUT]}!$PW_GUI_ICON_PATH/$BUTTON_SIZE.png!${translations[Delete shortcut for select file...]}:98"
         fi
 
-        [[ $DESKTOP_WITH_TIME == enabled ]] && search_desktop_file
+        search_desktop_file
+        unset DESKTOP_NAME_FILE PW_SHORTCUT_PROXY
+        if [[ -n ${DESKTOP_FILES_ARRAY[0]} ]] ; then
+            for df in "${DESKTOP_FILES_ARRAY[@]}" ; do
+                df="${df//"$PORT_WINE_PATH/"/}"
+                DESKTOP_NAME_FILE="${df//.desktop/}"
+            done
+        fi
         if [[ -z "${PW_COMMENT_DB}" ]] ; then
-            unset PW_SHORTCUT_PROXY
-            FILE_DESCRIPTION_ABBR=$(make_abbreviation "$FILE_DESCRIPTION")
-            PORTPROTON_NAME_ABBR=$(make_abbreviation "$PORTPROTON_NAME")
-            if [[ ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB^^} ]] && [[ ${PORTPROTON_NAME^^} != "${PORTWINE_DB^^}" ]] \
-            || (( ${#PORTPROTON_NAME_ABBR} > 2 )) && [[ ${PORTPROTON_NAME_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
+            [[ $FILE_DESCRIPTION != "" ]] && FILE_DESCRIPTION_ABBR=$(make_abbreviation "$FILE_DESCRIPTION")
+            [[ $PORTPROTON_NAME != "" ]] && PORTPROTON_NAME_ABBR=$(make_abbreviation "$PORTPROTON_NAME")
+            if [[ -n $DESKTOP_NAME_FILE ]] && [[ $DESKTOP_NAME_FILE != "" ]] ; then
+                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$DESKTOP_NAME_FILE" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+                PW_SHORTCUT_PROXY="$DESKTOP_NAME_FILE"
+            elif [[ ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB^^} ]] && [[ ${PORTPROTON_NAME^^} != "${PORTWINE_DB^^}" ]] ; then
                 PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTPROTON_NAME" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
                 PW_SHORTCUT_PROXY="$PORTPROTON_NAME"
-            elif [[ ${FILE_DESCRIPTION^^} =~ ${PORTWINE_DB^^} ]] && [[ ${FILE_DESCRIPTION^^} != "${PORTWINE_DB^^}" ]] \
-            || (( ${#FILE_DESCRIPTION_ABBR} > 2 )) && [[ ${FILE_DESCRIPTION_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
+            elif (( ${#PORTPROTON_NAME_ABBR} > 2 )) && [[ ${PORTPROTON_NAME_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
+                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTPROTON_NAME" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+                PW_SHORTCUT_PROXY="$PORTPROTON_NAME"
+            elif [[ ${FILE_DESCRIPTION^^} =~ ${PORTWINE_DB^^} ]] && [[ ${FILE_DESCRIPTION^^} != "${PORTWINE_DB^^}" ]] ; then
+                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$FILE_DESCRIPTION" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+                PW_SHORTCUT_PROXY="$FILE_DESCRIPTION"
+            elif (( ${#FILE_DESCRIPTION_ABBR} > 2 )) && [[ ${FILE_DESCRIPTION_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
                 PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$FILE_DESCRIPTION" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
                 PW_SHORTCUT_PROXY="$FILE_DESCRIPTION"
             else
@@ -549,6 +562,7 @@ if [[ -f "${portwine_exe}" ]] ; then
             fi
         else
             PW_COMMENT_DB="$PW_COMMENT_DB$(seconds_to_time "$TIME_CURRENT")"
+            PW_SHORTCUT_PROXY="$DESKTOP_NAME_FILE"
         fi
 
         export KEY_START="$RANDOM"

--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -502,8 +502,17 @@ if [[ -f "${portwine_exe}" ]] ; then
 
         [[ $DESKTOP_WITH_TIME == enabled ]] && search_desktop_file
         if [[ -z "${PW_COMMENT_DB}" ]] ; then
-            if [[ ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB^^} ]] && [[ ${PORTPROTON_NAME^^} != "${PORTWINE_DB^^}" ]] ; then
-                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "${PORTPROTON_NAME}" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+            unset PW_SHORTCUT_PROXY
+            FILE_DESCRIPTION_ABBR=$(make_abbreviation "$FILE_DESCRIPTION")
+            PORTPROTON_NAME_ABBR=$(make_abbreviation "$PORTPROTON_NAME")
+            if [[ ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB^^} ]] && [[ ${PORTPROTON_NAME^^} != "${PORTWINE_DB^^}" ]] \
+            || (( ${#PORTPROTON_NAME_ABBR} > 2 )) && [[ ${PORTPROTON_NAME_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
+                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTPROTON_NAME" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+                PW_SHORTCUT_PROXY="$PORTPROTON_NAME"
+            elif [[ ${FILE_DESCRIPTION^^} =~ ${PORTWINE_DB^^} ]] && [[ ${FILE_DESCRIPTION^^} != "${PORTWINE_DB^^}" ]] \
+            || (( ${#FILE_DESCRIPTION_ABBR} > 2 )) && [[ ${FILE_DESCRIPTION_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
+                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$FILE_DESCRIPTION" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+                PW_SHORTCUT_PROXY="$FILE_DESCRIPTION"
             else
                 unset PORTWINE_DB_PROXY PORTWINE_DB_NEW
                 PORTWINE_DB="${PORTWINE_DB//_/ }"
@@ -511,7 +520,7 @@ if [[ -f "${portwine_exe}" ]] ; then
                     PORTWINE_DB_UPPER="${PORTWINE_DB^^}"
                     PORTWINE_DB="${PORTWINE_DB_UPPER:0:1}${PORTWINE_DB:1}"
                 fi
-                if (( ${#PORTWINE_DB} > 2 )) ; then
+                if (( ${#PORTWINE_DB} > 3 )) ; then
                     for ((i=0 ; i<${#PORTWINE_DB} ; i++)) ; do
                         if [[ ${PORTWINE_DB:i:2} =~ ([a-z][A-Z]|[a-z][0-9]) ]] \
                         && [[ ! ${PORTWINE_DB:i:3} =~ ([a-z][A-Z]" "|[a-z][0-9]" ") ]] ; then
@@ -535,7 +544,8 @@ if [[ -f "${portwine_exe}" ]] ; then
                 else
                     PORTWINE_DB_NEW="$PORTWINE_DB"
                 fi
-                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "${PORTWINE_DB_NEW}" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTWINE_DB_NEW" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+                PW_SHORTCUT_PROXY="$PORTWINE_DB_NEW"
             fi
         else
             PW_COMMENT_DB="$PW_COMMENT_DB$(seconds_to_time "$TIME_CURRENT")"


### PR DESCRIPTION
1) Улучшил поиск name_desktop при создании шорткатов (то есть GameCenter теперь не будет ) и если создать дубликат вообще с непонятным названием, при его пересоздании предложит нормальное название и удалит лишние desktop файлы на тот же exe файл 
2) Добавил конвертацию .desktop файлов flatpak в натив и наоборот, есть ПП был установлен в той же директории
3) Исправил баг, когда при пересоздании ярлыка сбрасывалось время в игре (теперь сохраняется)
4) Снова исправил баг при создании нового ярлыка (чтобы наверху он был), не работал, если Time= был больше 0
5) Пофиксил баги у ПР, добавил unset для name_desktop

6) Добавил последний коммит ([Added PORTWINE_DB_NEW]) , чтобы не по exiftool названия создавались (они будут создаваться, но не так часто как раньше, только если название .exe файла схоже с тем, что находится в exiftool)

7) ещё занимался этим пром (23.10.24), дал возможность использовать пользовательские названия в приоритете 


