### PR TITLE
Updates for name_desktop and create_pw_comment

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -925,11 +925,11 @@ create_pw_comment () {
         if [[ -n $DESKTOP_NAME_FILE ]] ; then
             PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$DESKTOP_NAME_FILE" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
             PW_SHORTCUT_PROXY="$DESKTOP_NAME_FILE"
-        elif [[ ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB^^} && ${PORTPROTON_NAME} != "${PORTWINE_DB}" ]] \
+        elif [[ ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB^^} && $PORTPROTON_NAME != "$PORTWINE_DB" ]] \
         || [[ ${#PORTPROTON_NAME_ABBR} -gt 2 && ${PORTPROTON_NAME_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
             PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTPROTON_NAME" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
             PW_SHORTCUT_PROXY="$PORTPROTON_NAME"
-        elif [[ ${FILE_DESCRIPTION^^} =~ ${PORTWINE_DB^^} && ${FILE_DESCRIPTION} != "${PORTWINE_DB}" ]] \
+        elif [[ ${FILE_DESCRIPTION^^} =~ ${PORTWINE_DB^^} && $FILE_DESCRIPTION != "$PORTWINE_DB" ]] \
         || [[ ${#FILE_DESCRIPTION_ABBR} -gt 2 && ${FILE_DESCRIPTION_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
             PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$FILE_DESCRIPTION" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
             PW_SHORTCUT_PROXY="$FILE_DESCRIPTION"
@@ -2505,8 +2505,7 @@ pw_find_exe () {
 
     if [[ -n "${PW_SET_FIND_EXE}" ]] ; then
         portwine_exe="${PW_PATH_FOR_FIND}$(echo "${PW_SET_FIND_EXE}" | awk -F'|' '{print $1}')"
-        portwine_create_shortcut silent
-        restart_pp
+        portwine_create_shortcut
     fi
 }
 
@@ -4587,7 +4586,7 @@ relaxed - Same as fifo but allows tearing when below the monitors refresh rate.]
     1> "$PW_TMPFS_PATH/tmp_output_yad_fps_limit" 2>/dev/null &
 
     "${pw_yad}" --notebook --key="$KEY_EDIT_DB_GUI" --title "${translations[EDIT DB]}" --text-align=center \
-    --text "${translations[Change settings in database file for]} <b>${PORTWINE_DB}</b>\n ${translations[<b>NOTE:</b> To display help for each item, simply hover your mouse over the text]}" \
+    --text "${translations[Change settings in database file for]} <b>$PW_SHORTCUT_PROXY</b>\n ${translations[<b>NOTE:</b> To display help for each item, simply hover your mouse over the text]}" \
     --window-icon="$PW_GUI_ICON_PATH/portproton.svg" --separator=" " --expand \
     --gui-type="settings-base" \
     --gui-type-text="${NOTEBOOK_GUI_TYPE_TEXT}" --gui-type-layout="${NOTEBOOK_GUI_TYPE_LAYOUT}" \
@@ -5228,7 +5227,7 @@ gui_gamescope () {
 
     unset ADD_CHK_BOX_GS
     if [[ "${GAMESCOPE_INSTALLED}" == 1 ]] ; then
-        GAMESCOPE_NEED_INSTALL="${translations[Change settings gamescope for]} <b>${PORTWINE_DB}</b>\n ${translations[<b>NOTE:</b> To display help for each item, simply hover your mouse over the text]}"
+        GAMESCOPE_NEED_INSTALL="${translations[Change settings gamescope for]} <b>$PW_SHORTCUT_PROXY</b>\n ${translations[<b>NOTE:</b> To display help for each item, simply hover your mouse over the text]}"
         GS_CB="CB" && GS_CBE="CBE" && GS_NUM="NUM" && GS_NUMN="NUMN"
         for int_to_boole in ${PW_GS_LIST[@]} ; do
             if [[ "${!int_to_boole}" == "1" ]]

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -908,30 +908,31 @@ search_desktop_file () {
 create_pw_comment () {
     search_desktop_file
     unset DESKTOP_NAME_FILE PW_SHORTCUT_PROXY
-    if [[ -n ${DESKTOP_FILES_ARRAY[0]} ]] ; then
-        for df in "${DESKTOP_FILES_ARRAY[@]}" ; do
-            df="${df//"$PORT_WINE_PATH/"/}"
-            DESKTOP_NAME_FILE="${df//.desktop/}"
-        done
+    if [[ -n $DESKTOP_NAME_YAD ]] ; then
+        DESKTOP_NAME_FILE="${DESKTOP_NAME_YAD//.desktop/}"
+        unset DESKTOP_NAME_YAD
+    elif [[ -n $name_desktop ]] ; then
+        DESKTOP_NAME_FILE="$name_desktop"
+        unset name_desktop
+    elif [[ -n ${DESKTOP_FILES_ARRAY[0]} ]] \
+    && [[ -z ${DESKTOP_FILES_ARRAY[1]} ]] ; then
+        DESKTOP_NAME_FILE="${DESKTOP_FILES_ARRAY[0]//"$PORT_WINE_PATH/"/}"
+        DESKTOP_NAME_FILE="${DESKTOP_NAME_FILE//.desktop/}"
     fi
     if [[ -z "${PW_COMMENT_DB}" ]] ; then
-        [[ $FILE_DESCRIPTION != "" ]] && FILE_DESCRIPTION_ABBR=$(make_abbreviation "$FILE_DESCRIPTION")
-        [[ $PORTPROTON_NAME != "" ]] && PORTPROTON_NAME_ABBR=$(make_abbreviation "$PORTPROTON_NAME")
-        if [[ -n $DESKTOP_NAME_FILE ]] && [[ $DESKTOP_NAME_FILE != "" ]] ; then
+        [[ -n $PORTPROTON_NAME ]] && PORTPROTON_NAME_ABBR=$(make_abbreviation "$PORTPROTON_NAME")
+        [[ -n $FILE_DESCRIPTION ]] && FILE_DESCRIPTION_ABBR=$(make_abbreviation "$FILE_DESCRIPTION")
+        if [[ -n $DESKTOP_NAME_FILE ]] ; then
             PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$DESKTOP_NAME_FILE" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
             PW_SHORTCUT_PROXY="$DESKTOP_NAME_FILE"
-        elif [[ ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB^^} ]] && [[ ${PORTPROTON_NAME^^} != "${PORTWINE_DB^^}" ]] ; then
-            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTPROTON_NAME" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
-            PW_SHORTCUT_PROXY="$PORTPROTON_NAME"
-        elif (( ${#PORTPROTON_NAME_ABBR} > 2 )) && [[ ${PORTPROTON_NAME_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
-            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTPROTON_NAME" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
-            PW_SHORTCUT_PROXY="$PORTPROTON_NAME"
-        elif [[ ${FILE_DESCRIPTION^^} =~ ${PORTWINE_DB^^} ]] && [[ ${FILE_DESCRIPTION^^} != "${PORTWINE_DB^^}" ]] ; then
-            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$FILE_DESCRIPTION" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
-            PW_SHORTCUT_PROXY="$FILE_DESCRIPTION"
-        elif (( ${#FILE_DESCRIPTION_ABBR} > 2 )) && [[ ${FILE_DESCRIPTION_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
-            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$FILE_DESCRIPTION" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
-            PW_SHORTCUT_PROXY="$FILE_DESCRIPTION"
+        elif [[ ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB^^} && ${PORTPROTON_NAME} != "${PORTWINE_DB}" ]] \
+        || [[ ${#PORTPROTON_NAME_ABBR} -gt 2 && ${PORTPROTON_NAME_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
+                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTPROTON_NAME" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+                PW_SHORTCUT_PROXY="$PORTPROTON_NAME"
+        elif [[ ${FILE_DESCRIPTION^^} =~ ${PORTWINE_DB^^} && ${FILE_DESCRIPTION} != "${PORTWINE_DB}" ]] \
+        || [[ ${#FILE_DESCRIPTION_ABBR} -gt 2 && ${FILE_DESCRIPTION_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
+                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$FILE_DESCRIPTION" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+                PW_SHORTCUT_PROXY="$FILE_DESCRIPTION"
         else
             unset PORTWINE_DB_PROXY PORTWINE_DB_NEW
             PORTWINE_DB="${PORTWINE_DB//_/ }"
@@ -5588,11 +5589,12 @@ portwine_create_shortcut () {
                 for rm in "${DESKTOP_FILES_ARRAY[@]}" ; do
                     rm -f "$rm"
                 done
-                [[ $name_desktop == "" ]] && create_pw_comment && export name_desktop="$PW_SHORTCUT_PROXY"
             fi
         else
             try_remove_file "${PORT_WINE_PATH}/${name_desktop}.desktop"
         fi
+
+        [[ -z $name_desktop ]] && unset name_desktop && export name_desktop="$DESKTOP_NAME_FILE"
 
         echo "[Desktop Entry]" > "${PORT_WINE_PATH}/${name_desktop}.desktop"
         echo "Name=${name_desktop}" >> "${PORT_WINE_PATH}/${name_desktop}.desktop"
@@ -6178,6 +6180,7 @@ button_click () {
                     (( count++ ))
                 done
             fi
+            export DESKTOP_NAME_YAD="${PW_YAD_SET//"$PORT_WINE_PATH/"/}"
             if check_flatpak
             then PW_EXEC_FROM_DESKTOP="$(grep Exec "$PW_YAD_SET" | head -n 1 | sed 's|flatpak run ru.linux_gaming.PortProton|\"${PORT_SCRIPTS_PATH}/start.sh\"|' | awk -F'=' '{print $2}')"
             else PW_EXEC_FROM_DESKTOP="$(grep Exec "$PW_YAD_SET" | head -n 1 | awk -F"=env " '{print $2}')"

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -905,9 +905,9 @@ search_desktop_file () {
     fi
 }
 
-create_pw_comment () {
+create_name_desktop () {
     search_desktop_file
-    unset DESKTOP_NAME_FILE PW_SHORTCUT_PROXY
+    unset DESKTOP_NAME_FILE
     if [[ -n $DESKTOP_NAME_YAD ]] ; then
         DESKTOP_NAME_FILE="${DESKTOP_NAME_YAD//.desktop/}"
         unset DESKTOP_NAME_YAD
@@ -919,57 +919,56 @@ create_pw_comment () {
         DESKTOP_NAME_FILE="${DESKTOP_FILES_ARRAY[0]//"$PORT_WINE_PATH/"/}"
         DESKTOP_NAME_FILE="${DESKTOP_NAME_FILE//.desktop/}"
     fi
-    if [[ -z "${PW_COMMENT_DB}" ]] ; then
-        [[ -n $PORTPROTON_NAME ]] && PORTPROTON_NAME_ABBR=$(make_abbreviation "$PORTPROTON_NAME")
-        [[ -n $FILE_DESCRIPTION ]] && FILE_DESCRIPTION_ABBR=$(make_abbreviation "$FILE_DESCRIPTION")
-        if [[ -n $DESKTOP_NAME_FILE ]] ; then
-            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$DESKTOP_NAME_FILE" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
-            PW_SHORTCUT_PROXY="$DESKTOP_NAME_FILE"
-        elif [[ ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB^^} && $PORTPROTON_NAME != "$PORTWINE_DB" ]] \
-        || [[ ${#PORTPROTON_NAME_ABBR} -gt 2 && ${PORTPROTON_NAME_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
-            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTPROTON_NAME" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
-            PW_SHORTCUT_PROXY="$PORTPROTON_NAME"
-        elif [[ ${FILE_DESCRIPTION^^} =~ ${PORTWINE_DB^^} && $FILE_DESCRIPTION != "$PORTWINE_DB" ]] \
-        || [[ ${#FILE_DESCRIPTION_ABBR} -gt 2 && ${FILE_DESCRIPTION_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
-            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$FILE_DESCRIPTION" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
-            PW_SHORTCUT_PROXY="$FILE_DESCRIPTION"
-        else
-            unset PORTWINE_DB_PROXY PORTWINE_DB_NEW
-            PORTWINE_DB="${PORTWINE_DB//_/ }"
-            if [[ ${PORTWINE_DB:0:1} =~ [a-z] ]] ; then
-                PORTWINE_DB_UPPER="${PORTWINE_DB^^}"
-                PORTWINE_DB="${PORTWINE_DB_UPPER:0:1}${PORTWINE_DB:1}"
-            fi
-            if (( ${#PORTWINE_DB} > 3 )) ; then
-                for ((i=0 ; i<${#PORTWINE_DB} ; i++)) ; do
-                    if [[ ${PORTWINE_DB:i:2} =~ ([a-z][A-Z]|[a-z][0-9]) ]] \
-                    && [[ ! ${PORTWINE_DB:i:3} =~ ([a-z][A-Z]" "|[a-z][0-9]" ") ]] ; then
-                        PORTWINE_DB_PROXY+="${PORTWINE_DB:i:1} "
-                    elif [[ ${PORTWINE_DB:i:3} =~ [0-9][0-9][a-zA-Z] ]] ; then
-                        PORTWINE_DB_PROXY+="${PORTWINE_DB:i:2} "
-                        ((i++))
-                    else
-                        PORTWINE_DB_PROXY+="${PORTWINE_DB:i:1}"
-                    fi
-                done
-                for ((i=0 ; i<${#PORTWINE_DB_PROXY} ; i++)) ; do
-                    if [[ ${PORTWINE_DB_PROXY:i:2} =~ " "[a-z] ]] ; then
-                        PORTWINE_DB_UPPER="${PORTWINE_DB_PROXY:i:2}"
-                        PORTWINE_DB_NEW+="${PORTWINE_DB_UPPER^^}"
-                        ((i++))
-                    else
-                        PORTWINE_DB_NEW+="${PORTWINE_DB_PROXY:i:1}"
-                    fi
-                done
-            else
-                PORTWINE_DB_NEW="$PORTWINE_DB"
-            fi
-            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTWINE_DB_NEW" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
-            PW_SHORTCUT_PROXY="$PORTWINE_DB_NEW"
-        fi
+
+    [[ -n $PORTPROTON_NAME ]] && PORTPROTON_NAME_ABBR=$(make_abbreviation "$PORTPROTON_NAME")
+    [[ -n $FILE_DESCRIPTION ]] && FILE_DESCRIPTION_ABBR=$(make_abbreviation "$FILE_DESCRIPTION")
+
+    if [[ -z $PORTWINE_DB ]] ; then
+        PORTWINE_DB_DESKTOP="$(basename "${portwine_exe%.[Ee][Xx][Ee]}")"
     else
-        PW_COMMENT_DB="$PW_COMMENT_DB$(seconds_to_time "$TIME_CURRENT")"
-        PW_SHORTCUT_PROXY="$DESKTOP_NAME_FILE"
+        PORTWINE_DB_DESKTOP="$PORTWINE_DB"
+    fi
+
+    if [[ -n $DESKTOP_NAME_FILE ]] ; then
+        PW_NAME_DESKTOP_PROXY="$DESKTOP_NAME_FILE"
+    elif [[ -n $PORTPROTON_NAME && ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB_DESKTOP^^} && $PORTPROTON_NAME != "$PORTWINE_DB_DESKTOP" ]] \
+    || [[ -n $PORTPROTON_NAME && ${#PORTPROTON_NAME_ABBR} -gt 2 && ${PORTPROTON_NAME_ABBR^^} =~ ${PORTWINE_DB_DESKTOP^^} ]] ; then
+        PW_NAME_DESKTOP_PROXY="$PORTPROTON_NAME"
+    elif [[ -n $FILE_DESCRIPTION && ${FILE_DESCRIPTION^^} =~ ${PORTWINE_DB_DESKTOP^^} && $FILE_DESCRIPTION != "$PORTWINE_DB_DESKTOP" ]] \
+    || [[ -n $FILE_DESCRIPTION && ${#FILE_DESCRIPTION_ABBR} -gt 2 && ${FILE_DESCRIPTION_ABBR^^} =~ ${PORTWINE_DB_DESKTOP^^} ]] ; then
+        PW_NAME_DESKTOP_PROXY="$FILE_DESCRIPTION"
+    else
+        unset PORTWINE_DB_PROXY PORTWINE_DB_NEW
+        PORTWINE_DB_DESKTOP="${PORTWINE_DB_DESKTOP//_/ }"
+        if [[ ${PORTWINE_DB_DESKTOP:0:1} =~ [a-z] ]] ; then
+            PORTWINE_DB_UPPER="${PORTWINE_DB_DESKTOP^^}"
+            PORTWINE_DB_DESKTOP="${PORTWINE_DB_UPPER:0:1}${PORTWINE_DB_DESKTOP:1}"
+        fi
+        if (( ${#PORTWINE_DB_DESKTOP} > 3 )) ; then
+            for ((i=0 ; i<${#PORTWINE_DB_DESKTOP} ; i++)) ; do
+                if [[ ${PORTWINE_DB_DESKTOP:i:2} =~ ([a-z][A-Z]|[a-z][0-9]) ]] \
+                && [[ ! ${PORTWINE_DB_DESKTOP:i:3} =~ ([a-z][A-Z]" "|[a-z][0-9]" ") ]] ; then
+                    PORTWINE_DB_PROXY+="${PORTWINE_DB_DESKTOP:i:1} "
+                elif [[ ${PORTWINE_DB_DESKTOP:i:3} =~ [0-9][0-9][a-zA-Z] ]] ; then
+                    PORTWINE_DB_PROXY+="${PORTWINE_DB_DESKTOP:i:2} "
+                    ((i++))
+                else
+                    PORTWINE_DB_PROXY+="${PORTWINE_DB_DESKTOP:i:1}"
+                fi
+            done
+            for ((i=0 ; i<${#PORTWINE_DB_PROXY} ; i++)) ; do
+                if [[ ${PORTWINE_DB_PROXY:i:2} =~ " "[a-z] ]] ; then
+                    PORTWINE_DB_UPPER="${PORTWINE_DB_PROXY:i:2}"
+                    PORTWINE_DB_NEW+="${PORTWINE_DB_UPPER^^}"
+                    ((i++))
+                else
+                    PORTWINE_DB_NEW+="${PORTWINE_DB_PROXY:i:1}"
+                fi
+            done
+        else
+            PORTWINE_DB_NEW="$PORTWINE_DB_DESKTOP"
+        fi
+        PW_NAME_DESKTOP_PROXY="$PORTWINE_DB_NEW"
     fi
 }
 
@@ -4586,7 +4585,7 @@ relaxed - Same as fifo but allows tearing when below the monitors refresh rate.]
     1> "$PW_TMPFS_PATH/tmp_output_yad_fps_limit" 2>/dev/null &
 
     "${pw_yad}" --notebook --key="$KEY_EDIT_DB_GUI" --title "${translations[EDIT DB]}" --text-align=center \
-    --text "${translations[Change settings in database file for]} <b>$PW_SHORTCUT_PROXY</b>\n ${translations[<b>NOTE:</b> To display help for each item, simply hover your mouse over the text]}" \
+    --text "${translations[Change settings in database file for]} <b>$PW_NAME_DESKTOP_PROXY</b>\n ${translations[<b>NOTE:</b> To display help for each item, simply hover your mouse over the text]}" \
     --window-icon="$PW_GUI_ICON_PATH/portproton.svg" --separator=" " --expand \
     --gui-type="settings-base" \
     --gui-type-text="${NOTEBOOK_GUI_TYPE_TEXT}" --gui-type-layout="${NOTEBOOK_GUI_TYPE_LAYOUT}" \
@@ -5227,7 +5226,7 @@ gui_gamescope () {
 
     unset ADD_CHK_BOX_GS
     if [[ "${GAMESCOPE_INSTALLED}" == 1 ]] ; then
-        GAMESCOPE_NEED_INSTALL="${translations[Change settings gamescope for]} <b>$PW_SHORTCUT_PROXY</b>\n ${translations[<b>NOTE:</b> To display help for each item, simply hover your mouse over the text]}"
+        GAMESCOPE_NEED_INSTALL="${translations[Change settings gamescope for]} <b>$PW_NAME_DESKTOP_PROXY</b>\n ${translations[<b>NOTE:</b> To display help for each item, simply hover your mouse over the text]}"
         GS_CB="CB" && GS_CBE="CBE" && GS_NUM="NUM" && GS_NUMN="NUMN"
         for int_to_boole in ${PW_GS_LIST[@]} ; do
             if [[ "${!int_to_boole}" == "1" ]]
@@ -5534,8 +5533,9 @@ portwine_create_shortcut () {
     [[ -z "${PW_SHORTCUT_DESKTOP}" ]] && PW_SHORTCUT_DESKTOP="TRUE"
     [[ -z "${PW_SHORTCUT_STEAM}" ]] && PW_SHORTCUT_STEAM="FALSE"
 
-    [[ -z $PW_SHORTCUT_PROXY ]] && create_pw_comment 
-    export name_desktop="$PW_SHORTCUT_PROXY"
+    unset name_desktop
+    create_name_desktop
+    export name_desktop="$PW_NAME_DESKTOP_PROXY"
 
     [[ -z "${name_desktop_png}" ]] && name_desktop_png="${PORTPROTON_NAME// /_}"
 
@@ -5593,7 +5593,7 @@ portwine_create_shortcut () {
             try_remove_file "${PORT_WINE_PATH}/${name_desktop}.desktop"
         fi
 
-        [[ -z $name_desktop ]] && unset name_desktop && export name_desktop="$DESKTOP_NAME_FILE"
+        [[ -z $name_desktop ]] && create_name_desktop && export name_desktop="$PW_NAME_DESKTOP_PROXY"
 
         echo "[Desktop Entry]" > "${PORT_WINE_PATH}/${name_desktop}.desktop"
         echo "Name=${name_desktop}" >> "${PORT_WINE_PATH}/${name_desktop}.desktop"

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -267,7 +267,7 @@ EOF
                     while [[ ! $line =~ msgid ]] ; do
                         msgstr+=$line
                         read -r line
-                        if [[ $line == "" ]] ; then
+                        if [[ -z $line ]] ; then
                             break
                         fi
                     done
@@ -756,8 +756,8 @@ background_pid () {
                 export bg_pid"${arg3}"="$PID" ;;
             --end)
                 PID=$(get_bg_pid bg_pid"${arg3}")
-                [[ $PID == "" ]] && return 1
-                wait "$PID" && return 0 ;;
+                [[ -z $PID ]] && return 1
+                wait "$PID" 2>/dev/null && return 0 ;;
         esac
     fi
 }
@@ -927,12 +927,12 @@ create_pw_comment () {
             PW_SHORTCUT_PROXY="$DESKTOP_NAME_FILE"
         elif [[ ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB^^} && ${PORTPROTON_NAME} != "${PORTWINE_DB}" ]] \
         || [[ ${#PORTPROTON_NAME_ABBR} -gt 2 && ${PORTPROTON_NAME_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
-                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTPROTON_NAME" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
-                PW_SHORTCUT_PROXY="$PORTPROTON_NAME"
+            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PORTPROTON_NAME" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+            PW_SHORTCUT_PROXY="$PORTPROTON_NAME"
         elif [[ ${FILE_DESCRIPTION^^} =~ ${PORTWINE_DB^^} && ${FILE_DESCRIPTION} != "${PORTWINE_DB}" ]] \
         || [[ ${#FILE_DESCRIPTION_ABBR} -gt 2 && ${FILE_DESCRIPTION_ABBR^^} =~ ${PORTWINE_DB^^} ]] ; then
-                PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$FILE_DESCRIPTION" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
-                PW_SHORTCUT_PROXY="$FILE_DESCRIPTION"
+            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$FILE_DESCRIPTION" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+            PW_SHORTCUT_PROXY="$FILE_DESCRIPTION"
         else
             unset PORTWINE_DB_PROXY PORTWINE_DB_NEW
             PORTWINE_DB="${PORTWINE_DB//_/ }"
@@ -1016,10 +1016,10 @@ seconds_to_time () {
     if [[ $minutes =~ ^0$ ]] ; then
         hours=${hours//" ${translations[and]} "/}
         minutes=
-        if [[ $days == "" ]] || [[ $hours == "" ]] ; then
+        if [[ -z $days ]] || [[ -z $hours ]] ; then
             days=${days//","/}
         fi
-        if [[ $days == "" ]] && [[ $hours == "" ]] ; then
+        if [[ -z $days ]] && [[ -z $hours ]] ; then
             minutes="${translations[less than a minute]}"
         fi
     elif [[ $minutes =~ ^1$ ]] ; then

--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -497,7 +497,12 @@ if [[ -f "${portwine_exe}" ]] ; then
             PW_SHORTCUT="${translations[DELETE SHORTCUT]}!$PW_GUI_ICON_PATH/$BUTTON_SIZE.png!${translations[Delete shortcut for select file...]}:98"
         fi
 
-        create_pw_comment
+        create_name_desktop
+        if [[ -z "${PW_COMMENT_DB}" ]] ; then
+            PW_COMMENT_DB="${translations[Launching]} <b>$(print_wrapped "$PW_NAME_DESKTOP_PROXY" "50")</b>$(seconds_to_time "$TIME_CURRENT")"
+        else
+            PW_COMMENT_DB="$PW_COMMENT_DB$(seconds_to_time "$TIME_CURRENT")"
+        fi
 
         export KEY_START="$RANDOM"
         if [[ "${PW_GUI_START}" == "NOTEBOOK" ]] ; then


### PR DESCRIPTION
1) DESKTOP_NAME_FILE теперь берётся из 3х мест (из главного меню по клику на ярлык, при создании ярлыка (новое название файла, при создании ярлыка с другим названием и как раньше из search_desktop_file функции (правда из этой функции он может только на 1ый ярлык найти .desktop файл, на остальные он тоже находит, но при запуске ярлыка с простого клика по нему, непонятно как определять, то что был нажат именно он, а не другой дубликат какой-то) , если не удалять старый ярлык, то в комментариях будет старое название (этот пр фиксит)
2) create_pw_comment сделал красивее и компактнее
3) пофиксил когда name_desktop пустой (то есть если при создании ярлыка написать пустое название), если было пустым, он и создавал пустой .desktop без название, теперь он по новой найдет название для него 
4) != "" заменил на -n , == "" на -z. То что там не работало вчера у меня где-то (то что это использовал), по другой причине это было
5) create_pw_comment теперь больше нет
6) исправлено отображение названия приложения в основных настройках и gamescope