### PR TITLE
Added make_acronym for create_name_desktop

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -38,28 +38,28 @@ print_wrapped () {
 }
 export -f print_wrapped
 
-make_abbreviation () {
-    local words new_word i
-    words=($1)
-    # Создаем новое слово, состоящее из начальных букв слов
-    new_word="${words[0]:0:1}"
-    for ((i=1 ; i<${#words[@]} ; i++)) ; do
-        new_word+="${words[$i]:0:1}"
-    done
-    echo "$new_word"
-}
-export -f make_abbreviation
-
 make_acronym () {
-    local word acronym i
-    word=$1
-    for (( i=0 ; i<${#word} ; i++ )) ; do
-        if [[ ${word:$i:1} =~ ^[A-Z]$ ]] ; then
-            acronym+="${word:$i:1}"
-        fi
+    local words acronym i
+    words=($1)
+    acronym="${words[0]:0:1}"
+    for ((i=1 ; i<${#words[@]} ; i++)) ; do
+        acronym+="${words[$i]:0:1}"
     done
     echo "$acronym"
 }
+export -f make_acronym
+
+make_abbreviation () {
+    local word abbreviation i
+    word=$1
+    for (( i=0 ; i<${#word} ; i++ )) ; do
+        if [[ ${word:$i:1} =~ ^[A-Z]$ ]] ; then
+            abbreviation+="${word:$i:1}"
+        fi
+    done
+    echo "$abbreviation"
+}
+export -f make_abbreviation
 
 check_variables () { [[ -z ${!1} ]] && export $1="$2" ;}
 
@@ -960,19 +960,15 @@ create_name_desktop () {
 
     if [[ -n $DESKTOP_NAME_FILE ]] ; then
         PW_NAME_DESKTOP_PROXY="$DESKTOP_NAME_FILE"
-    elif [[ -n $DESKTOP_NAME_FILE_OLD ]] ; then
+    elif [[ -n $DESKTOP_NAME_FILE_OLD && ${PORTWINE_DB_DESKTOP^^} =~ ${DESKTOP_NAME_FILE_OLD^^} ]] ; then
         PW_NAME_DESKTOP_PROXY="$DESKTOP_NAME_FILE_OLD"
     elif [[ -n $PORTPROTON_NAME && ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB_DESKTOP^^} && $PORTPROTON_NAME != "$PORTWINE_DB_DESKTOP" ]] \
-    || [[ -n $PORTPROTON_NAME && ${#PORTPROTON_NAME_ABBR} -gt 2 && ${PORTPROTON_NAME_ABBR^^} =~ ${PORTWINE_DB_DESKTOP^^} ]] \
-    || [[ -n $PORTPROTON_NAME && ${#PORTPROTON_NAME_ACRO} -gt 2 && ${PORTPROTON_NAME_ACRO^^} =~ ${PORTWINE_DB_DESKTOP^^} ]] \
-    || [[ -n $PORTPROTON_NAME && ${#PORTPROTON_NAME_ABBR} -gt 2 && ${PORTWINE_DB_DESKTOP^^} =~ ${PORTPROTON_NAME_ABBR^^} ]] \
+    || [[ -n $PORTPROTON_NAME && ${#PORTPROTON_NAME_ABBR} -gt 2 && ${PORTWINE_DB_DESKTOP^^} =~ $PORTPROTON_NAME_ABBR ]] \
     || [[ -n $PORTPROTON_NAME && ${#PORTPROTON_NAME_ACRO} -gt 2 && ${PORTWINE_DB_DESKTOP^^} =~ ${PORTPROTON_NAME_ACRO^^} ]]
     then
         PW_NAME_DESKTOP_PROXY="$PORTPROTON_NAME"
     elif [[ -n $FILE_DESCRIPTION && ${FILE_DESCRIPTION^^} =~ ${PORTWINE_DB_DESKTOP^^} && $FILE_DESCRIPTION != "$PORTWINE_DB_DESKTOP" ]] \
-    || [[ -n $FILE_DESCRIPTION && ${#FILE_DESCRIPTION_ABBR} -gt 2 && ${FILE_DESCRIPTION_ABBR^^} =~ ${PORTWINE_DB_DESKTOP^^} ]] \
-    || [[ -n $FILE_DESCRIPTION && ${#FILE_DESCRIPTION_ACRO} -gt 2 && ${FILE_DESCRIPTION_ACRO^^} =~ ${PORTWINE_DB_DESKTOP^^} ]] \
-    || [[ -n $FILE_DESCRIPTION && ${#FILE_DESCRIPTION_ABBR} -gt 2 && ${PORTWINE_DB_DESKTOP^^} =~ ${FILE_DESCRIPTION_ABBR^^} ]] \
+    || [[ -n $FILE_DESCRIPTION && ${#FILE_DESCRIPTION_ABBR} -gt 2 && ${PORTWINE_DB_DESKTOP^^} =~ $FILE_DESCRIPTION_ABBR ]] \
     || [[ -n $FILE_DESCRIPTION && ${#FILE_DESCRIPTION_ACRO} -gt 2 && ${PORTWINE_DB_DESKTOP^^} =~ ${FILE_DESCRIPTION_ACRO^^} ]]
     then
         PW_NAME_DESKTOP_PROXY="$FILE_DESCRIPTION"

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -50,6 +50,17 @@ make_abbreviation () {
 }
 export -f make_abbreviation
 
+make_acronym () {
+    local word acronym i
+    word=$1
+    for (( i=0 ; i<${#word} ; i++ )) ; do
+        if [[ ${word:$i:1} =~ ^[A-Z]$ ]] ; then
+            acronym+="${word:$i:1}"
+        fi
+    done
+    echo "$acronym"
+}
+
 check_variables () { [[ -z ${!1} ]] && export $1="$2" ;}
 
 add_to_var () {
@@ -917,7 +928,10 @@ search_desktop_file () {
 
 create_name_desktop () {
     search_desktop_file
-    unset DESKTOP_NAME_FILE
+    if [[ -n $DESKTOP_NAME_FILE ]] ; then
+        DESKTOP_NAME_FILE_OLD=$DESKTOP_NAME_FILE
+        unset DESKTOP_NAME_FILE
+    fi
     if [[ -n $DESKTOP_NAME_YAD ]] ; then
         DESKTOP_NAME_FILE="${DESKTOP_NAME_YAD//.desktop/}"
         unset DESKTOP_NAME_YAD
@@ -930,22 +944,37 @@ create_name_desktop () {
         DESKTOP_NAME_FILE="${DESKTOP_NAME_FILE//.desktop/}"
     fi
 
-    [[ -n $PORTPROTON_NAME ]] && PORTPROTON_NAME_ABBR=$(make_abbreviation "$PORTPROTON_NAME")
-    [[ -n $FILE_DESCRIPTION ]] && FILE_DESCRIPTION_ABBR=$(make_abbreviation "$FILE_DESCRIPTION")
-
     if [[ -z $PORTWINE_DB ]] ; then
         PORTWINE_DB_DESKTOP="$(basename "${portwine_exe%.[Ee][Xx][Ee]}")"
     else
         PORTWINE_DB_DESKTOP="$PORTWINE_DB"
     fi
+    if [[ -n $PORTPROTON_NAME ]] ; then
+        PORTPROTON_NAME_ABBR=$(make_abbreviation "$PORTPROTON_NAME")
+        PORTPROTON_NAME_ACRO=$(make_acronym "$PORTPROTON_NAME")
+    fi
+    if [[ -n $FILE_DESCRIPTION ]] ; then
+        FILE_DESCRIPTION_ABBR=$(make_abbreviation "$FILE_DESCRIPTION")
+        FILE_DESCRIPTION_ACRO=$(make_acronym "$FILE_DESCRIPTION")
+    fi
 
     if [[ -n $DESKTOP_NAME_FILE ]] ; then
         PW_NAME_DESKTOP_PROXY="$DESKTOP_NAME_FILE"
+    elif [[ -n $DESKTOP_NAME_FILE_OLD ]] ; then
+        PW_NAME_DESKTOP_PROXY="$DESKTOP_NAME_FILE_OLD"
     elif [[ -n $PORTPROTON_NAME && ${PORTPROTON_NAME^^} =~ ${PORTWINE_DB_DESKTOP^^} && $PORTPROTON_NAME != "$PORTWINE_DB_DESKTOP" ]] \
-    || [[ -n $PORTPROTON_NAME && ${#PORTPROTON_NAME_ABBR} -gt 2 && ${PORTPROTON_NAME_ABBR^^} =~ ${PORTWINE_DB_DESKTOP^^} ]] ; then
+    || [[ -n $PORTPROTON_NAME && ${#PORTPROTON_NAME_ABBR} -gt 2 && ${PORTPROTON_NAME_ABBR^^} =~ ${PORTWINE_DB_DESKTOP^^} ]] \
+    || [[ -n $PORTPROTON_NAME && ${#PORTPROTON_NAME_ACRO} -gt 2 && ${PORTPROTON_NAME_ACRO^^} =~ ${PORTWINE_DB_DESKTOP^^} ]] \
+    || [[ -n $PORTPROTON_NAME && ${#PORTPROTON_NAME_ABBR} -gt 2 && ${PORTWINE_DB_DESKTOP^^} =~ ${PORTPROTON_NAME_ABBR^^} ]] \
+    || [[ -n $PORTPROTON_NAME && ${#PORTPROTON_NAME_ACRO} -gt 2 && ${PORTWINE_DB_DESKTOP^^} =~ ${PORTPROTON_NAME_ACRO^^} ]]
+    then
         PW_NAME_DESKTOP_PROXY="$PORTPROTON_NAME"
     elif [[ -n $FILE_DESCRIPTION && ${FILE_DESCRIPTION^^} =~ ${PORTWINE_DB_DESKTOP^^} && $FILE_DESCRIPTION != "$PORTWINE_DB_DESKTOP" ]] \
-    || [[ -n $FILE_DESCRIPTION && ${#FILE_DESCRIPTION_ABBR} -gt 2 && ${FILE_DESCRIPTION_ABBR^^} =~ ${PORTWINE_DB_DESKTOP^^} ]] ; then
+    || [[ -n $FILE_DESCRIPTION && ${#FILE_DESCRIPTION_ABBR} -gt 2 && ${FILE_DESCRIPTION_ABBR^^} =~ ${PORTWINE_DB_DESKTOP^^} ]] \
+    || [[ -n $FILE_DESCRIPTION && ${#FILE_DESCRIPTION_ACRO} -gt 2 && ${FILE_DESCRIPTION_ACRO^^} =~ ${PORTWINE_DB_DESKTOP^^} ]] \
+    || [[ -n $FILE_DESCRIPTION && ${#FILE_DESCRIPTION_ABBR} -gt 2 && ${PORTWINE_DB_DESKTOP^^} =~ ${FILE_DESCRIPTION_ABBR^^} ]] \
+    || [[ -n $FILE_DESCRIPTION && ${#FILE_DESCRIPTION_ACRO} -gt 2 && ${PORTWINE_DB_DESKTOP^^} =~ ${FILE_DESCRIPTION_ACRO^^} ]]
+    then
         PW_NAME_DESKTOP_PROXY="$FILE_DESCRIPTION"
     else
         unset PORTWINE_DB_PROXY PORTWINE_DB_NEW


### PR DESCRIPTION
Аббревиатура — это сокращенная форма слова, используемая вместо полного слова (например, Inc.). Акроним — это слово, образованное из первых букв каждого из слов в фразе или названии (например, NREL или DOE).

Функция для создания акронимов уже была (только называлась неправильно), добавил правильную функцию для создания аббревиатур. В чём заключается смысл. Есть к примеру exe файл названием oalinst , в exiftool у него название OpenAL Installer. Новая функция по созданию аббревиатур из OpenAL Installer сделает OALI и если сравнивать с oalinst в верхнем регистре,  [[ OALINST =~ OALI ]] это будет true и можно использовать название из exiftool. (предыдущая по созданию акронимов сделает OI просто, [[ OALINST =~ OI ]] будет false, зато если файл называется gow.exe, в exitfool God of War, [[ GOW =~ GOW ]], будет true. То есть обе эти функции нужны) 

Добавил DESKTOP_NAME_FILE_OLD, в чём заключается смысл. Он сохраняет в себя предыдущее название у DESKTOP_NAME_FILE. На примере vkplay, если у vkplay сейчас пересоздать ярлык на пустоту, то пройдя через все этапы create_name_desktop функции (не найдя соответствий с exiftool, потому что там gamecenter), он придёт к выводу, то что название нужно создать по названию файла, VKPlayLoader, то есть он создаст VKPlay Loader, но если добавить данную проверку, он сравнит VKPlayLoader с предыдущим названием vkplay, и придёт к выводу, то что лучше использовать vkplay, а не VKPlayLoader
(можно было сделать это проще, сразу в функции по созданию шорткатов брать DESKTOP_NAME_FILE, а не повторно вызывать функцию, но в таком случае, если испортить название у файла к примеру God of War, написать 123, а потом пустить пустоту, он оставит 123, когда в нынешным состоянии создаст снова God of War и на мой взгляд это лучше)
