### PR TITLE
Added choice of GTK themes (default, light, dark)

### DIFF
--- a/data_from_portwine/locales/PortProton.pot
+++ b/data_from_portwine/locales/PortProton.pot
@@ -1381,6 +1381,21 @@ msgid   "If downloading steam covers is enabled, they will be downloaded and "
         "is unavailable for some reason)"
 msgstr  ""
 
+msgid   "default"
+msgstr  ""
+
+msgid   "compact"
+msgstr  ""
+
+msgid   "classic"
+msgstr  ""
+
+msgid   "dark"
+msgstr  ""
+
+msgid   "light"
+msgstr  ""
+
 msgid   "Choose a graphics card to run the game"
 msgstr  ""
 
@@ -1400,10 +1415,16 @@ msgstr  ""
 msgid   "Fixes sound popling if choice alsa"
 msgstr  ""
 
-msgid   "Choice gui themes"
+msgid   "Select PortProton theme"
 msgstr  ""
 
 msgid   "Allows you to select a theme for PortProton"
+msgstr  ""
+
+msgid   "Select gtk theme"
+msgstr  ""
+
+msgid   "Allows you to select a theme for GTK."
 msgstr  ""
 
 msgid   "Time display"

--- a/data_from_portwine/locales/es/LC_MESSAGES/PortProton.po
+++ b/data_from_portwine/locales/es/LC_MESSAGES/PortProton.po
@@ -1804,6 +1804,21 @@ msgstr ""
 "crearán. (La desactivación se proporciona en los casos en que su descarga no "
 "esté disponible por algún motivo)"
 
+msgid "default"
+msgstr "por defecto"
+
+msgid "compact"
+msgstr "compacto"
+
+msgid "classic"
+msgstr "clásico"
+
+msgid "dark"
+msgstr "oscuro"
+
+msgid "light"
+msgstr "ligero"
+
 msgid "Choose a graphics card to run the game"
 msgstr "Elige una tarjeta gráfica para ejecutar el juego"
 
@@ -1826,11 +1841,17 @@ msgstr "Controlador de audio de vino elegido"
 msgid "Fixes sound popling if choice alsa"
 msgstr "Corrige el sonido estallido de elección alsa alsa"
 
-msgid "Choice gui themes"
-msgstr "Temas de interfaz gráfica de usuario elegidos"
+msgid "Select PortProton theme"
+msgstr "Seleccione el tema PortProton"
 
 msgid "Allows you to select a theme for PortProton"
 msgstr "Le permite seleccionar un tema para PortProton"
+
+msgid "Select gtk theme"
+msgstr "Seleccione el tema gtk"
+
+msgid "Allows you to select a theme for GTK."
+msgstr "Le permite seleccionar un tema para GTK."
 
 msgid "Time display"
 msgstr "Mostrar tiempo"
@@ -2221,6 +2242,9 @@ msgid ""
 "--autoinstall and the name of what needs to be installed is given in the "
 "list below:"
 msgstr ""
+
+#~ msgid "Choice gui themes"
+#~ msgstr "Temas de interfaz gráfica de usuario elegidos"
 
 #~ msgid ""
 #~ "A higher number of duplicate desktop files were found for this file."

--- a/data_from_portwine/locales/ru/LC_MESSAGES/PortProton.po
+++ b/data_from_portwine/locales/ru/LC_MESSAGES/PortProton.po
@@ -1782,6 +1782,21 @@ msgstr ""
 "создаваться. (Отключение предусмотрено в тех случаях, когда их скачивание по "
 "каким-то причинам недоступно)"
 
+msgid "default"
+msgstr "по умолчанию"
+
+msgid "compact"
+msgstr "компактная"
+
+msgid "classic"
+msgstr "классическая"
+
+msgid "dark"
+msgstr "тёмная"
+
+msgid "light"
+msgstr "светлая"
+
 msgid "Choose a graphics card to run the game"
 msgstr "Выбрать видеокарту для запуска игры"
 
@@ -1805,11 +1820,17 @@ msgstr "Выбрать звуковой драйвер"
 msgid "Fixes sound popling if choice alsa"
 msgstr "Выбор alsa исправляет заикание звука"
 
-msgid "Choice gui themes"
-msgstr "Выбор графической темы"
+msgid "Select PortProton theme"
+msgstr "Выбрать тему PortProton"
 
 msgid "Allows you to select a theme for PortProton"
 msgstr "Позволяет выбрать тему для PortProton"
+
+msgid "Select gtk theme"
+msgstr "Выбрать тему GTK"
+
+msgid "Allows you to select a theme for GTK."
+msgstr "Позволяет выбрать светлую или тёмную тему"
 
 msgid "Time display"
 msgstr "Отображение времени"
@@ -2216,6 +2237,9 @@ msgid ""
 msgstr ""
 "--autoinstall и название того, что необходимо установить, указано в списке "
 "ниже:"
+
+#~ msgid "Choice gui themes"
+#~ msgstr "Выбор графической темы"
 
 #~ msgid ""
 #~ "A higher number of duplicate desktop files were found for this file."

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -5619,12 +5619,27 @@ gui_userconf () {
         YAD_DPI_VAR="disabled"
     fi
 
+    if [[ $GUI_THEME == default ]] ; then GUI_THEME=${translations[default]}
+    elif [[ $GUI_THEME == compact ]] ; then GUI_THEME=${translations[compact]}
+    elif [[ $GUI_THEME == classic ]] ; then GUI_THEME=${translations[classic]}
+    fi
+
+    if [[ -z $GTK_THEME ]] ; then
+        YAD_GTK_THEME="${translations[default]}!${translations[light]}!${translations[dark]}"
+    else
+        if [[ $GTK_THEME =~ :dark$ ]]
+        then YAD_GTK_THEME="${translations[dark]}!${translations[light]}!${translations[default]}"
+        else YAD_GTK_THEME="${translations[light]}!${translations[dark]}!${translations[default]}"
+        fi
+    fi
+
     "${pw_yad}" --plug=$KEY_USERCONF_GUI --tabnum="2" --form --columns=1 --separator="@" --homogeneous-row \
     --gui-type-text="$PANED_GUI_TYPE_TEXT_DOWN" --gui-type-layout="$PANED_GUI_TYPE_LAYOUT_DOWN" \
     --field="${translations[Choose a graphics card to run the game]}!${translations[Select which video card will be used to run the game (used for all running games and programs in PortProton)]} :CB" "$(combobox_fix --disabled "$GPU_VAR" "$GET_GPU_NAMES")" \
     --field="${translations[Force dpi for fonts]}!${translations[Here you can set forced dpi for fonts in wine]} :CB" "$(combobox_fix --disabled "$YAD_DPI_VAR" "96 (100%)!120 (125%)!144 (150%)!168 (175%)!192 (200%)!216 (225%)!240 (250%)!264 (275%)!288 (300%)")" \
     --field="${translations[Choice wine audio driver]}!${translations[Fixes sound popling if choice alsa]} :CB" "$(combobox_fix --disabled "$SOUND_DRIVER_VAR" "alsa!oss!pulse")" \
-    --field="${translations[Choice gui themes]}!${translations[Allows you to select a theme for PortProton]} :CB" "$(combobox_fix "$GUI_THEME" "default!compact!classic")" \
+    --field="${translations[Select PortProton theme]}!${translations[Allows you to select a theme for PortProton]} :CB" "$(combobox_fix "$GUI_THEME" "${translations[default]}!${translations[compact]}!${translations[classic]}")" \
+    --field="${translations[Select gtk theme]}!${translations[Allows you to select a theme for GTK.]} :CB" "$(combobox_fix "$YAD_GTK_THEME")" \
     --field="${translations[Time display]}!${translations[Displays time spent in an application or game]} :CB" "$(combobox_fix --disabled "$DESKTOP_WITH_TIME" "enabled")" \
     --field="${translations[Sort shortcuts by time]}!${translations[This setting sorts the shortcuts in the main menu depending on the time spent in the application or game]} :CB" "$(combobox_fix --disabled "$SORT_WITH_TIME" "enabled")" \
     1> "${PW_TMPFS_PATH}/tmp_yad_userconf_set_cb" 2>/dev/null &
@@ -5663,9 +5678,20 @@ gui_userconf () {
             PW_WINE_DPI_VALUE="${PW_ADD_SETTINGS_UC[1]}"
             PW_SOUND_DRIVER_USE="${PW_ADD_SETTINGS_UC[2]}"
             GUI_THEME="${PW_ADD_SETTINGS_UC[3]}"
-            DESKTOP_WITH_TIME="${PW_ADD_SETTINGS_UC[4]}"
-            SORT_WITH_TIME="${PW_ADD_SETTINGS_UC[5]}"
-            edit_user_conf_from_gui PW_GPU_USE PW_WINE_DPI_VALUE PW_SOUND_DRIVER_USE GUI_THEME DESKTOP_WITH_TIME SORT_WITH_TIME
+            if [[ $GUI_THEME == ${translations[default]} ]] ; then GUI_THEME=default
+            elif [[ $GUI_THEME == ${translations[compact]} ]] ; then GUI_THEME=compact
+            elif [[ $GUI_THEME == ${translations[classic]} ]] ; then GUI_THEME=classic
+            fi
+            GTK_THEME="${PW_ADD_SETTINGS_UC[4]}"
+            YAD_GTK_THEME=$(gsettings get org.gnome.desktop.interface gtk-theme)
+            YAD_GTK_THEME=${YAD_GTK_THEME//\'/}
+            if [[ $GTK_THEME == ${translations[default]} ]] ; then unset GTK_THEME
+            elif [[ $GTK_THEME == ${translations[light]} ]] ; then GTK_THEME="$YAD_GTK_THEME:light"
+            elif [[ $GTK_THEME == ${translations[dark]} ]] ; then GTK_THEME="$YAD_GTK_THEME:dark"
+            fi
+            DESKTOP_WITH_TIME="${PW_ADD_SETTINGS_UC[5]}"
+            SORT_WITH_TIME="${PW_ADD_SETTINGS_UC[6]}"
+            edit_user_conf_from_gui PW_GPU_USE PW_WINE_DPI_VALUE PW_SOUND_DRIVER_USE GUI_THEME GTK_THEME DESKTOP_WITH_TIME SORT_WITH_TIME
             restart_pp
             ;;
     esac

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -5624,13 +5624,20 @@ gui_userconf () {
     elif [[ $GUI_THEME == classic ]] ; then GUI_THEME=${translations[classic]}
     fi
 
-    if [[ -z $GTK_THEME ]] ; then
-        YAD_GTK_THEME="${translations[default]}!${translations[light]}!${translations[dark]}"
-    else
-        if [[ $GTK_THEME =~ :dark$ ]]
-        then YAD_GTK_THEME="${translations[dark]}!${translations[light]}!${translations[default]}"
-        else YAD_GTK_THEME="${translations[light]}!${translations[dark]}!${translations[default]}"
+    if command -v gsettings ; then
+        YAD_GTK_THEME_CHECK=$(gsettings get org.gnome.desktop.interface gtk-theme)
+        YAD_GTK_THEME_CHECK=${YAD_GTK_THEME_CHECK//\'/}
+        if [[ -n $YAD_GTK_THEME_CHECK ]] ; then
+            if [[ ! ${YAD_GTK_THEME_CHECK,,} == adwaita ]] ; then
+                YAD_GTK_THEME="$YAD_GTK_THEME_CHECK:${translations[light]}!$YAD_GTK_THEME_CHECK:${translations[dark]}!"
+            elif [[ ${YAD_GTK_THEME_CHECK,,} == breeze ]] ; then
+                YAD_GTK_THEME="$YAD_GTK_THEME_CHECK!"
+            fi
         fi
+    fi
+    if [[ -z $GTK_THEME ]] ; then GTK_THEME=${translations[default]}
+    elif [[ $GTK_THEME =~ light$ ]] ; then GTK_THEME="${GTK_THEME//light/${translations[light]}}"
+    elif [[ $GTK_THEME =~ dark$ ]] ; then GTK_THEME="${GTK_THEME//dark/${translations[dark]}}"
     fi
 
     "${pw_yad}" --plug=$KEY_USERCONF_GUI --tabnum="2" --form --columns=1 --separator="@" --homogeneous-row \
@@ -5639,7 +5646,7 @@ gui_userconf () {
     --field="${translations[Force dpi for fonts]}!${translations[Here you can set forced dpi for fonts in wine]} :CB" "$(combobox_fix --disabled "$YAD_DPI_VAR" "96 (100%)!120 (125%)!144 (150%)!168 (175%)!192 (200%)!216 (225%)!240 (250%)!264 (275%)!288 (300%)")" \
     --field="${translations[Choice wine audio driver]}!${translations[Fixes sound popling if choice alsa]} :CB" "$(combobox_fix --disabled "$SOUND_DRIVER_VAR" "alsa!oss!pulse")" \
     --field="${translations[Select PortProton theme]}!${translations[Allows you to select a theme for PortProton]} :CB" "$(combobox_fix "$GUI_THEME" "${translations[default]}!${translations[compact]}!${translations[classic]}")" \
-    --field="${translations[Select gtk theme]}!${translations[Allows you to select a theme for GTK.]} :CB" "$(combobox_fix "$YAD_GTK_THEME")" \
+    --field="${translations[Select gtk theme]}!${translations[Allows you to select a theme for GTK.]} :CB" "$(combobox_fix "$GTK_THEME" "${YAD_GTK_THEME}Adwaita:${translations[light]}!Adwaita:${translations[dark]}!${translations[default]}")" \
     --field="${translations[Time display]}!${translations[Displays time spent in an application or game]} :CB" "$(combobox_fix --disabled "$DESKTOP_WITH_TIME" "enabled")" \
     --field="${translations[Sort shortcuts by time]}!${translations[This setting sorts the shortcuts in the main menu depending on the time spent in the application or game]} :CB" "$(combobox_fix --disabled "$SORT_WITH_TIME" "enabled")" \
     1> "${PW_TMPFS_PATH}/tmp_yad_userconf_set_cb" 2>/dev/null &
@@ -5683,11 +5690,9 @@ gui_userconf () {
             elif [[ $GUI_THEME == ${translations[classic]} ]] ; then GUI_THEME=classic
             fi
             GTK_THEME="${PW_ADD_SETTINGS_UC[4]}"
-            YAD_GTK_THEME=$(gsettings get org.gnome.desktop.interface gtk-theme)
-            YAD_GTK_THEME=${YAD_GTK_THEME//\'/}
             if [[ $GTK_THEME == ${translations[default]} ]] ; then unset GTK_THEME
-            elif [[ $GTK_THEME == ${translations[light]} ]] ; then GTK_THEME="$YAD_GTK_THEME:light"
-            elif [[ $GTK_THEME == ${translations[dark]} ]] ; then GTK_THEME="$YAD_GTK_THEME:dark"
+            elif [[ $GTK_THEME =~ ${translations[light]} ]] ; then GTK_THEME="${GTK_THEME//${translations[light]}/light}"
+            elif [[ $GTK_THEME =~ ${translations[dark]} ]] ; then GTK_THEME="${GTK_THEME//${translations[dark]}/dark}"
             fi
             DESKTOP_WITH_TIME="${PW_ADD_SETTINGS_UC[5]}"
             SORT_WITH_TIME="${PW_ADD_SETTINGS_UC[6]}"


### PR DESCRIPTION
1) Перевёл темы PortProton и GTK на русский и испанский.
2) Добавил выбор темы GTK по умолчанию (то есть текущая и которая всегда есть), светлая и тёмная (светлая и тёмная могут отличаться от по умолчанию, по этому по умолчанию нужно

3) исправил работу на alt linux