### PR TITLE
Fixed bug for portwine_missing_shortcut

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -6030,9 +6030,12 @@ portwine_missing_shortcut () {
     if [[ $? -eq "0" ]] ; then
         portwine_delete_shortcut
     fi
-    if [[ -n "$TAB_MAIN_MENU" ]]
-    then restart_pp
-    else exit 0
+    if [[ -n $AI_SKIP ]]
+    then
+        unset TAB_MAIN_MENU
+        restart_pp
+    else
+        exit 0
     fi
 }
 

--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -702,7 +702,13 @@ else
         PW_GENERATE_BUTTONS+="--field=   $(print_wrapped "${PW_DESKTOP_FILES_SHOW//".desktop"/""}" "25" "...")!${PW_NAME_D_ICON_48}.png!:FBTNR%@bash -c \"button_click --desktop "${PW_DESKTOP_FILES// /#@_@#}"\"%"
     done
 
-    MAIN_GUI_ROWS="$(( ( AMOUNT_GENERATE_BUTTONS + 1 ) / MAIN_GUI_COLUMNS + 1 ))"
+    if [[ $AMOUNT_GENERATE_BUTTONS == 1 ]] ; then
+        MAIN_GUI_ROWS=1
+    elif (( AMOUNT_GENERATE_BUTTONS <= 5 )) ; then
+        MAIN_GUI_ROWS=2
+    else
+        MAIN_GUI_ROWS="$(( ( AMOUNT_GENERATE_BUTTONS + 1 ) / MAIN_GUI_COLUMNS + 1 ))"
+    fi
 
     if [[ -z $PW_DESKTOP_FILES ]]
     then export PW_GUI_SORT_TABS=(1 2 3 4 5)


### PR DESCRIPTION
1)Пофиксил небольшой баг, если к примеру сейчас зайти в из главного меню в глобальные настройки, а потом нажать по ярлыку у которого нет .exe файла, предложит его удалить , или нажать отмену, и если нажать отмену, то вернёт в главное меню не на 1ый таб к ярлыкам, а на таб с настройками portproton
2)Для start.sh, когда меньше 5 или равно ярлыков, нужен column 2, чтобы отображалось в 3 ряда, а не в 2