### PR TITLE
Added eval for systemd-inhibit

### DIFF
--- a/data_from_portwine/locales/PortProton.pot
+++ b/data_from_portwine/locales/PortProton.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2024-11-02 10:04+0500\n"
+        "POT-Creation-Date: 2024-11-13 08:17+0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -319,6 +319,9 @@ msgid   "OK"
 msgstr  ""
 
 msgid   "Do you want to installing recommended libraries in the new prefix:"
+msgstr  ""
+
+msgid   "Launched"
 msgstr  ""
 
 msgid   "d3dadapter9.so.1.0.0 - Not found in the system.\\nInstall the "
@@ -1256,7 +1259,7 @@ msgid   "Force use sdl videodriver x11, works with BACKEND SDL. (Default is "
         "wayland)"
 msgstr  ""
 
-msgid   "If specified, sets a base output height to linearly scale the cursor "
+msgid   "if specified, sets a base output height to linearly scale the cursor "
         "against."
 msgstr  ""
 
@@ -1385,6 +1388,9 @@ msgid   "If downloading steam covers is enabled, they will be downloaded and "
         "is unavailable for some reason)"
 msgstr  ""
 
+msgid   "Recommended value"
+msgstr  ""
+
 msgid   "default"
 msgstr  ""
 
@@ -1394,13 +1400,10 @@ msgstr  ""
 msgid   "classic"
 msgstr  ""
 
-msgid   "dark"
-msgstr  ""
-
 msgid   "light"
 msgstr  ""
 
-msgid   "Recommended value"
+msgid   "dark"
 msgstr  ""
 
 msgid   "Choose a graphics card to run the game"

--- a/data_from_portwine/locales/es/LC_MESSAGES/PortProton.po
+++ b/data_from_portwine/locales/es/LC_MESSAGES/PortProton.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-02 10:04+0500\n"
-"PO-Revision-Date: 2024-10-26 13:58+0500\n"
+"POT-Creation-Date: 2024-11-13 08:17+0500\n"
+"PO-Revision-Date: 2024-11-13 08:18+0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es_ES\n"
@@ -348,6 +348,9 @@ msgstr "OK"
 
 msgid "Do you want to installing recommended libraries in the new prefix:"
 msgstr "¿Quieres instalar las bibliotecas recomendadas en el nuevo prefijo:"
+
+msgid "Launched"
+msgstr "Lanzado"
 
 msgid ""
 "d3dadapter9.so.1.0.0 - Not found in the system.\\nInstall the missing "
@@ -1636,8 +1639,9 @@ msgstr ""
 "Forzar el uso del controlador de video SDL x11, funciona con el backend SDL. "
 "(Por defecto es Wayland)."
 
+#, fuzzy
 msgid ""
-"If specified, sets a base output height to linearly scale the cursor against."
+"if specified, sets a base output height to linearly scale the cursor against."
 msgstr ""
 "Si se especifica, establece una altura de salida base para escalar "
 "linealmente el cursor."
@@ -1810,6 +1814,9 @@ msgstr ""
 "crearán. (La desactivación se proporciona en los casos en que su descarga no "
 "esté disponible por algún motivo)"
 
+msgid "Recommended value"
+msgstr ""
+
 msgid "default"
 msgstr "por defecto"
 
@@ -1819,14 +1826,11 @@ msgstr "compacto"
 msgid "classic"
 msgstr "clásico"
 
-msgid "dark"
-msgstr "oscuro"
-
 msgid "light"
 msgstr "ligero"
 
-msgid "Recommended value"
-msgstr ""
+msgid "dark"
+msgstr "oscuro"
 
 msgid "Choose a graphics card to run the game"
 msgstr "Elige una tarjeta gráfica para ejecutar el juego"

--- a/data_from_portwine/locales/ru/LC_MESSAGES/PortProton.po
+++ b/data_from_portwine/locales/ru/LC_MESSAGES/PortProton.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-02 10:04+0500\n"
-"PO-Revision-Date: 2024-11-02 10:05+0500\n"
+"POT-Creation-Date: 2024-11-13 08:17+0500\n"
+"PO-Revision-Date: 2024-11-13 08:18+0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ru_RU\n"
@@ -350,6 +350,9 @@ msgstr "OK"
 
 msgid "Do you want to installing recommended libraries in the new prefix:"
 msgstr "Хотите добавить рекомендуемые библиотеки в префикс:"
+
+msgid "Launched"
+msgstr "Запущено"
 
 msgid ""
 "d3dadapter9.so.1.0.0 - Not found in the system.\\nInstall the missing "
@@ -1615,8 +1618,9 @@ msgstr ""
 "запуском), работает вместе с SDL BACKEND (используется по умолчанию в "
 "Wayland сессии)"
 
+#, fuzzy
 msgid ""
-"If specified, sets a base output height to linearly scale the cursor against."
+"if specified, sets a base output height to linearly scale the cursor against."
 msgstr ""
 "Если указано, устанавливает базовую высоту вывода для линейного "
 "масштабирования курсора."
@@ -1788,6 +1792,9 @@ msgstr ""
 "создаваться. (Отключение предусмотрено в тех случаях, когда их скачивание по "
 "каким-то причинам недоступно)"
 
+msgid "Recommended value"
+msgstr "Рекомендуемое значение"
+
 msgid "default"
 msgstr "по умолчанию"
 
@@ -1797,14 +1804,11 @@ msgstr "компактная"
 msgid "classic"
 msgstr "классическая"
 
-msgid "dark"
-msgstr "тёмная"
-
 msgid "light"
 msgstr "светлая"
 
-msgid "Recommended value"
-msgstr "Рекомендуемое значение"
+msgid "dark"
+msgstr "тёмная"
 
 msgid "Choose a graphics card to run the game"
 msgstr "Выбрать видеокарту для запуска игры"
@@ -2245,6 +2249,9 @@ msgid ""
 msgstr ""
 "--autoinstall и название того, что необходимо установить, указано в списке "
 "ниже:"
+
+#~ msgid "Running"
+#~ msgstr "Запущено"
 
 #~ msgid "Choice gui themes"
 #~ msgstr "Выбор графической темы"

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -3318,7 +3318,7 @@ start_portwine () {
     if command -v systemd-inhibit &>/dev/null \
     && [[ "$GAMEMODERUN" != "1" ]]
     then
-        PW_INHIBIT_SLR="systemd-inhibit --mode=block --who=ru.linux_gaming.PortProton --why=${PW_NAME_DESKTOP_PROXY// /_}"
+        PW_INHIBIT_SLR="eval systemd-inhibit --mode=block --who=ru.linux_gaming.PortProton --why=\"${translations[Launched]} $PW_NAME_DESKTOP_PROXY\""
         print_info "Screensaver will be inhibit"
     fi
     pw_other_fixes


### PR DESCRIPTION
1) systemd-inhibit таким образом работает с пробелами. Конечно часто пишут, то что eval небезопасен, но возможно его именно для подобных задач и создавали?))
2) В данном случае, эмпирическим путём проверил безопасность eval в данном месте, на примере 
![Снимок экрана_20241113_095246](https://github.com/user-attachments/assets/5c035c86-fb10-423e-a215-7bd918f9f507)

В чём заключается смысл, мы создаём переменную qwe помещая в неё ls, asd="eval \"$qwe\"", то есть аналог того, что в пр, $asd и enter в терминале и $asd выполняет ls, в данном случае не безопасно, потому что qwe может быть не ls, и выполнит более вредоносную команду. Но, PW_INHIBIT_SLR="eval systemd-inhibit --mode=block --who=ru.linux_gaming.PortProton --why=\"$qwe\"" , qwe с ls и при $PW_INHIBIT_SLR  не выполнит ls, потому что eval чётко привязан к systemd-inhibit , a $qwe не сможет выполнить какую-то команду, потому что это всего лишь аргумент --why= у systemd-inhibit