### PR TITLE
Fix exit with PW_GUI_DISABLED_CS=1

### DIFF
--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -905,6 +905,7 @@ case "$PW_YAD_SET" in
 esac
 
 case "$PW_YAD_SET" in
+    '') ;;
     98) portwine_change_shortcut ;;
     100) portwine_create_shortcut ;;
     DEBUG|102) portwine_start_debug ;;


### PR DESCRIPTION
Опять поломался выход с отключеным GUI - остается иконка в трее висеть. 
Потому что PW_YAD_SET пустой и попадаем на звездочку, где происходит выход без остановки portwine