### PR TITLE
SteamAppID as name steam game

### DIFF
--- a/data_from_portwine/scripts/add_in_steam.sh
+++ b/data_from_portwine/scripts/add_in_steam.sh
@@ -487,8 +487,6 @@ addNonSteamGame() {
 		[[ -z "${NOSTSHPATH}" ]] && NOSTSHPATH="${STEAM_SCRIPTS}/${name_desktop}.sh"
 		NOSTAPPNAME="${name_desktop}"
 		NOSTAPPID=$(getAppId "${NOSTSHPATH}")
-		echo "NOSTAPPNAME: ${NOSTAPPNAME}"
-		echo "NOSTAPPID: ${NOSTAPPID}"
 		if [[ -z "${NOSTAPPID}" ]]; then
 			NOSTEXEPATH="${NOSTSHPATH}"
 			if [[ -z "${NOSTSTDIR}" ]]; then
@@ -514,7 +512,7 @@ addNonSteamGame() {
 			fi
 
 			if [[ "${USE_STEAMAPPID_AS_NAME:-0}" == "1" ]]; then
-				getSteamId "${NOSTAPPNAME}"
+				SteamAppId=$(getSteamId "${NOSTAPPNAME}")
 				[[ -n "${SteamAppId}" ]] && NOSTAPPNAME="${SteamAppId}"
 			fi
 

--- a/data_from_portwine/scripts/add_in_steam.sh
+++ b/data_from_portwine/scripts/add_in_steam.sh
@@ -107,7 +107,7 @@ getSteamId() {
 	if [[ -n "${SteamIds:-}" ]] && jq -e --arg key "${NOSTAPPNAME}" 'has($key)' <<< "${SteamIds}" > /dev/null; then
 		SteamAppId=$(jq -r --arg key "${NOSTAPPNAME}" '.[$key]' <<< "${SteamIds}")
 	else
-		if [[ -n "${1:-}" ]] && [[ "${USE_STEABGRIDDB:-1}" == "1" ]]; then
+		if [[ -n "${1:-}" ]] && [[ "${USE_STEAMGRIDDB:-1}" == "1" ]]; then
 			getSteamGridDBId "${NOSTAPPNAME}" > /dev/null
 		fi
 		if [[ ${SteamGridDBTypeSteam} == true ]]; then
@@ -115,7 +115,7 @@ getSteamId() {
 			if jq -e ".success == true" <<< "${SRES}" > /dev/null 2>&1; then
 				SteamAppId="$(jq -r '.data.platforms.steam.id' <<< "${SRES}")"
 			fi
-		elif [[ "${USE_STEABGRIDDB:-1}" == "0" ]]; then
+		elif [[ "${USE_STEAMGRIDDB:-1}" == "0" ]]; then
 			SteamAppId="$(curl -s --connect-timeout 5 -m 10 "https://api.steampowered.com/ISteamApps/GetAppList/v2/" | jq --arg name "${NOSTAPPNAME}" '.applist.apps[] | select(.name == $name) | .appid')"
 		fi
 		SteamIds=$(jq --arg key "${NOSTAPPNAME}" --arg value "${SteamAppId:-}" '. + {($key): $value}' <<< "${SteamIds:-$(jq -n '{}')}")
@@ -129,7 +129,7 @@ getSteamId() {
 getSteamGridDBId() {
 	unset SteamGridDBId
 	NOSTAPPNAME="$1"
-	if [[ "${USE_STEABGRIDDB:-1}" == "1" ]] && [[ -n "${SGDBAPIKEY}" ]] && [[ -n "${BASESTEAMGRIDDBAPI}" ]] && curl -fs --connect-timeout 5 -m 10 -o /dev/null "${BASESTEAMGRIDDBAPI}"; then
+	if [[ "${USE_STEAMGRIDDB:-1}" == "1" ]] && [[ -n "${SGDBAPIKEY}" ]] && [[ -n "${BASESTEAMGRIDDBAPI}" ]] && curl -fs --connect-timeout 5 -m 10 -o /dev/null "${BASESTEAMGRIDDBAPI}"; then
 		SGDBRES=$(curl -Ls --connect-timeout 5 -m 10 -H "Authorization: Bearer ${SGDBAPIKEY}" "${BASESTEAMGRIDDBAPI}/search/autocomplete/${NOSTAPPNAME// /_}")
 		if jq -e ".success == true and (.data | length > 0)" <<< "${SGDBRES}" > /dev/null 2>&1; then
 			if jq -e '.data[0].types | contains(["steam"])' <<< "${SGDBRES}" > /dev/null; then
@@ -141,7 +141,7 @@ getSteamGridDBId() {
 			echo "${SteamGridDBId}"
 		fi
 	else
-		USE_STEABGRIDDB="0"
+		USE_STEAMGRIDDB="0"
 	fi
 }
 
@@ -351,7 +351,7 @@ downloadImageSteamGridDB() {
 
 addGrids() {
 	[[ -z "${SteamGridDBId}" ]] && getSteamGridDBId "${name_desktop}" > /dev/null
-	if [[ -z "${SteamAppId}" ]] && [[ "${USE_STEABGRIDDB:-1}" == "0" ]]; then
+	if [[ -z "${SteamAppId}" ]] && [[ "${USE_STEAMGRIDDB:-1}" == "0" ]]; then
 		getSteamId > /dev/null
 	fi
 	if [[ -n "${SteamGridDBId}" ]] || [[ -n "${SteamAppId}" ]]; then

--- a/data_from_portwine/scripts/add_in_steam.sh
+++ b/data_from_portwine/scripts/add_in_steam.sh
@@ -204,10 +204,12 @@ listInstalledSteamGames() {
 		jq -n '[]'
 	else
 		for manifest_file in "${manifests[@]}"; do
-			name="$(grep -Po '"name"\s+"\K[^"]+' "$manifest_file")";
-			if [[ ! "${name}" =~ ^(Proton |Steam Linux Runtime|Steamworks Common) ]]; then
+			name="$(grep -Po '"name"\s+"\K[^"]+' "${manifest_file}")";
+			stateflags="$(grep -Po '"StateFlags"\s+"\K\d+' "${manifest_file}")"
+# 			if [[ ! "${name}" =~ ^(Proton |Steam Linux Runtime|Steamworks Common) ]]; then
+			if ((stateflags & 4)) && grep -q '"SharedDepots"' "${manifest_file}"; then
 				jq -n \
-					--arg id "$(grep -Po '"appid"\s+"\K\d+' "$manifest_file")" \
+					--arg id "$(grep -Po '"appid"\s+"\K\d+' "${manifest_file}")" \
 					--arg name "${name}" \
 					'{id: $id, name: $name}'
 			fi


### PR DESCRIPTION
- Добавил возможность использовать SteamAppId вместо названия игры которое будет добавлено в стим. Тем самым стим будет подтягивать раскладки геймпадов для игр. Для активации используется переменная `USE_STEAMAPPID_AS_NAME`  `(addNonSteamGame)`
- Добавлена проверка "StateFlags" и наличие секции "SharedDepots" в манифесте `(listInstalledSteamGames)`
- Добавил кеширование списка приложений получаемых с сервера steam.  Так же поиск по этому списку теперь регистронезависимый `(getSteamId)`
- Убрал опечатку в имени переменной `USE_STEAMGRIDDB`