### PR TITLE
Fixed scripts for PORTPROTON_NAME, name_desktop_png, PW_ICON_FOR_YAD

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -2928,23 +2928,31 @@ edit_user_conf_from_gui () {
 }
 
 pw_create_gui_png () {
-    unset PORTPROTON_NAME name_desktop_png
-    basename_portwine_exe="$(basename "${portwine_exe}")"
-    if echo "$basename_portwine_exe" | grep -ie 'setup\|install\|\.msi$' &>/dev/null ; then
-        export PW_ICON_FOR_YAD="${PORT_WINE_PATH}/data/img/setup.png"
-        export name_desktop_png="setup"
-        return 0
-    elif echo "$basename_portwine_exe" | grep -ie '\.reg$' &>/dev/null ; then
-        export PW_ICON_FOR_YAD="${PORT_WINE_PATH}/data/img/reg.png"
-        export name_desktop_png="reg"
-        return 0
-    elif echo "$basename_portwine_exe"| grep -ie '\.bat$' &>/dev/null ; then
-        export PW_ICON_FOR_YAD="${PORT_WINE_PATH}/data/img/bat.png"
-        export name_desktop_png="bat"
-        return 0
+    if [[ -z $name_desktop_png ]] ; then
+        basename_portwine_exe="$(basename "${portwine_exe}")"
+        if echo "$basename_portwine_exe" | grep -ie 'setup\|install\|\.msi$' &>/dev/null ; then
+            export PW_ICON_FOR_YAD="${PORT_WINE_PATH}/data/img/setup.png"
+            export name_desktop_png="setup"
+            return 0
+        elif echo "$basename_portwine_exe" | grep -ie '\.reg$' &>/dev/null ; then
+            export PW_ICON_FOR_YAD="${PORT_WINE_PATH}/data/img/reg.png"
+            export name_desktop_png="reg"
+            return 0
+        elif echo "$basename_portwine_exe"| grep -ie '\.bat$' &>/dev/null ; then
+            export PW_ICON_FOR_YAD="${PORT_WINE_PATH}/data/img/bat.png"
+            export name_desktop_png="bat"
+            return 0
+        fi
+        name_desktop_png="${PORTPROTON_NAME// /_}"
+        if [[ $name_desktop_png =~ [\!\%\$\&\<] ]] ; then
+            local ICON_NAME_REGEX=(\! % \$ \& \<)
+            for i in "${ICON_NAME_REGEX[@]}" ; do
+                name_desktop_png="${name_desktop_png//$i/}"
+            done
+        fi
     fi
+
     if [[ -z "$PORTPROTON_NAME" ]] \
-    || [[ -z "$FILE_DESCRIPTION" ]] \
     || [[ "$PW_NO_RESTART_PPDB" == "1" ]]
     then
         if [[ -n "${PORTWINE_CREATE_SHORTCUT_NAME}" ]] ; then
@@ -6197,14 +6205,6 @@ portwine_create_shortcut () {
     create_name_desktop
     export name_desktop="$PW_NAME_DESKTOP_PROXY"
 
-    [[ -z "${name_desktop_png}" ]] && name_desktop_png="${PORTPROTON_NAME// /_}"
-    if [[ $name_desktop_png =~ [\!\%\$\&\<] ]] ; then
-        local ICON_NAME_REGEX=(\! % \$ \& \<)
-        for i in "${ICON_NAME_REGEX[@]}" ; do
-            name_desktop_png="${name_desktop_png//$i/}"
-        done
-    fi
-
     OUTPUT=$("${pw_yad}" --title="${translations[Choices]}" --form \
     --gui-type="settings-shortcut" \
     --gui-type-box="${NOTEBOOK_GUI_TYPE_BOX}" --gui-type-layout="${NOTEBOOK_GUI_TYPE_LAYOUT}" \
@@ -6408,13 +6408,6 @@ portwine_change_shortcut () {
     export name_desktop="$PW_NAME_DESKTOP_PROXY"
 
     pw_create_gui_png
-    [[ -z "${name_desktop_png}" ]] && name_desktop_png="${PORTPROTON_NAME// /_}"
-    if [[ $name_desktop_png =~ [\!\%\$\&\<] ]] ; then
-        local ICON_NAME_REGEX=(\! % \$ \& \<)
-        for i in "${ICON_NAME_REGEX[@]}" ; do
-            name_desktop_png="${name_desktop_png//$i/}"
-        done
-    fi
 
     OUTPUT=$("${pw_yad}" --title="${translations[Choices]}" --form \
     --gui-type="settings-shortcut" \

--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -101,7 +101,7 @@ else
     unset PW_GUI_DISABLED_CS
 fi
 
-unset MANGOHUD PW_NO_ESYNC PW_NO_FSYNC PW_VULKAN_USE WINEDLLOVERRIDES PW_NO_WRITE_WATCH PW_YAD_SET PW_ICON_FOR_YAD
+unset MANGOHUD PW_NO_ESYNC PW_NO_FSYNC PW_VULKAN_USE WINEDLLOVERRIDES PW_NO_WRITE_WATCH PW_YAD_SET
 unset PW_CHECK_AUTOINSTALL PW_VKBASALT_EFFECTS PW_VKBASALT_FFX_CAS PORTWINE_DB PORTWINE_DB_FILE RADV_PERFTEST
 unset CHK_SYMLINK_FILE PW_MESA_GL_VERSION_OVERRIDE PW_VKD3D_FEATURE_LEVEL PATH_TO_GAME PW_START_DEBUG PORTPROTON_NAME PW_PATH
 unset PW_PREFIX_NAME VULKAN_MOD PW_WINE_VER PW_ADD_TO_ARGS_IN_RUNTIME PW_GAMEMODERUN_SLR PW_WINE_CPU_TOPOLOGY
@@ -617,7 +617,7 @@ if [[ -f "$portwine_exe" ]] ; then
                 for db_unset in $PORTWINE_DB_FOR_UNSET ; do
                     unset "$db_unset"
                 done
-                unset portwine_exe KEY_START
+                unset portwine_exe KEY_START name_desktop_png PW_ICON_FOR_YAD
                 print_info "Restarting..."
                 restart_pp
                 ;;


### PR DESCRIPTION
Исправил скрипты для PORTPROTON_NAME, name_desktop_png, PW_ICON_FOR_YAD

1) PORTPROTON_NAME почему-то всегда unset был и каждый раз заходил на выполнение к exiftool и -z "$FILE_DESCRIPTION"  этому тоже мешал.
2)  name_desktop_png unset и каждый раз выполнялся, допустим когда нужно было изменить ярлык, хотя по факту его unset нужно только когда выходим в главное меню.
3) PW_ICON_FOR_YAD unset только когда возвращаемся в главное меню, потому что когда изменяем ярлык, происходит restart_pp, и он делал unset, когда это не нужно делать