### PR TITLE
Update supplied dxvk vkd3d

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -3706,7 +3706,7 @@ start_portwine () {
                 try_force_link_file "${WINEDIR}/lib/wine/d8vk/d3d8.dll" "${WINEPREFIX}/drive_c/windows/syswow64/d3d8.dll"
                 try_force_link_file "${WINEDIR}/lib64/wine/d8vk/d3d8.dll" "${WINEPREFIX}/drive_c/windows/system32/d3d8.dll"
                 var_winedlloverride_update "d3d8=n"
-            elif [[ -f "${WINEDIR}/lib64/wine/dxvk/d3d8.dll" || "${WINEDIR}/lib/wine/dxvk/x86_64-windows/d3d8.dll" ]]
+            elif [[ -f "${WINEDIR}/lib64/wine/dxvk/d3d8.dll" || -f "${WINEDIR}/lib/wine/dxvk/x86_64-windows/d3d8.dll" ]]
             then add_to_var CP_DXVK_FILES "d3d8"
             else add_to_var CP_WINE_FILES "d3d8"
             fi
@@ -3740,7 +3740,7 @@ start_portwine () {
             try_remove_file "${WINEPREFIX}/drive_c/windows/system32/dgVoodoo.conf"
             try_force_link_file "${DGV2CONF}" "${WINEPREFIX}/drive_c/windows/system32/dgVoodoo.conf"
 
-            if [[ $PW_USE_SUPPLIED_DXVK_VKD3D == "1" ]] ; then
+            if [[ $PW_USE_SUPPLIED_DXVK_VKD3D != "0" ]] ; then
                 rm_from_var CP_DXVK_FILES "d3d9"
             else
                 case "${PW_VULKAN_USE}" in
@@ -4023,7 +4023,7 @@ start_portwine () {
                     try_force_link_file "${PATH_TO_VKD3D_FILES}/x86/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/syswow64/${wine_vkd3d_dll}.dll"
                     try_force_link_file "${PATH_TO_VKD3D_FILES}/x64/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/system32/${wine_vkd3d_dll}.dll" ;;
             esac
-            var_winedlloverride_update "${wine_vkd3d_dll}=n"
+            [[ ! $wine_vkd3d_dll =~ libvkd3d ]] && var_winedlloverride_update "${wine_vkd3d_dll}=n"
         done
         create_new_dir "${PATH_TO_VKD3D_FILES}/vkd3d_cache"
         export VKD3D_SHADER_CACHE_PATH="${PATH_TO_VKD3D_FILES}/vkd3d_cache"

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -3693,6 +3693,7 @@ start_portwine () {
     && [[ ! $PW_WINE_USE =~ (PROTON_LG|WINE_LG) ]] \
     && [[ ! $PW_VULKAN_USE =~ (0|3) ]] \
     && [[ -f "${WINEDIR}/lib64/wine/dxvk/d3d9.dll" || -f "${WINEDIR}/lib/wine/dxvk/x86_64-windows/d3d9.dll" ]] ; then
+        export DXVK_ASYNC="1"
         if [[ -f "${WINEDIR}/lib64/wine/dxvk/d3d10.dll" && -f "${WINEDIR}/lib64/wine/dxvk/d3d10_1.dll" ]] ; then
             CP_DXVK_FILES="d3d11 d3d10core d3d10_1 d3d10 d3d9 dxgi"
             CP_WINE_FILES=""

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -3692,7 +3692,7 @@ start_portwine () {
     if [[ $PW_USE_SUPPLIED_DXVK_VKD3D == "1" ]] \
     && [[ ! $PW_WINE_USE =~ (PROTON_LG|WINE_LG) ]] \
     && [[ ! $PW_VULKAN_USE =~ (0|3) ]] \
-    && [[ -f "${WINEDIR}/lib64/wine/dxvk/d3d9.dll" ]] ; then
+    && [[ -f "${WINEDIR}/lib64/wine/dxvk/d3d9.dll" || -f "${WINEDIR}/lib/wine/dxvk/x86_64-windows/d3d9.dll" ]] ; then
         if [[ -f "${WINEDIR}/lib64/wine/dxvk/d3d10.dll" && -f "${WINEDIR}/lib64/wine/dxvk/d3d10_1.dll" ]] ; then
             CP_DXVK_FILES="d3d11 d3d10core d3d10_1 d3d10 d3d9 dxgi"
             CP_WINE_FILES=""
@@ -3705,12 +3705,13 @@ start_portwine () {
                 try_force_link_file "${WINEDIR}/lib/wine/d8vk/d3d8.dll" "${WINEPREFIX}/drive_c/windows/syswow64/d3d8.dll"
                 try_force_link_file "${WINEDIR}/lib64/wine/d8vk/d3d8.dll" "${WINEPREFIX}/drive_c/windows/system32/d3d8.dll"
                 var_winedlloverride_update "d3d8=n"
-            elif [[ -f "${WINEDIR}/lib64/wine/dxvk/d3d8.dll" ]]
+            elif [[ -f "${WINEDIR}/lib64/wine/dxvk/d3d8.dll" || "${WINEDIR}/lib/wine/dxvk/x86_64-windows/d3d8.dll" ]]
             then add_to_var CP_DXVK_FILES "d3d8"
             else add_to_var CP_WINE_FILES "d3d8"
             fi
         fi
-        if [[ -f "${WINEDIR}/lib64/wine/vkd3d-proton/d3d12core.dll" && -f "${WINEDIR}/lib64/vkd3d/libvkd3d-1.dll" ]] ; then
+        if [[ -f "${WINEDIR}/lib64/wine/vkd3d-proton/d3d12core.dll" && -f "${WINEDIR}/lib64/vkd3d/libvkd3d-1.dll" ]] \
+        || [[ -f "${WINEDIR}/lib/wine/vkd3d-proton/x86_64-windows/d3d12core.dll" && -f "${WINEDIR}/lib/vkd3d/x86_64-windows/libvkd3d-1.dll" ]] ; then
             CP_VKD3D_FILES="d3d12 d3d12core libvkd3d-1 libvkd3d-shader-1"
         elif [[ -f "${WINEDIR}/lib64/wine/vkd3d-proton/d3d12.dll" && -f "${WINEDIR}/lib64/vkd3d/libvkd3d-shader-1.dll" ]] ; then
             CP_VKD3D_FILES="d3d12 libvkd3d-1 libvkd3d-shader-1"
@@ -3719,6 +3720,7 @@ start_portwine () {
             CP_VKD3D_FILES="libvkd3d-1 libvkd3d-shader-1"
             add_to_var CP_WINE_FILES "d3d12 d3d12core"
         fi
+        [[ -f "${WINEDIR}/lib/wine/dxvk/x86_64-windows/d3d9.dll" ]] && PW_USE_SUPPLIED_DXVK_VKD3D="2"
     else
         PW_USE_SUPPLIED_DXVK_VKD3D="0"
     fi
@@ -3951,13 +3953,17 @@ start_portwine () {
     if [[ -n "$CP_DXVK_FILES" ]] ; then
         print_info "Try create symlink DXVK files..."
         for wine_dxvk_dll in $CP_DXVK_FILES ; do
-            if [[ $PW_USE_SUPPLIED_DXVK_VKD3D == "1" ]] ; then
-                try_force_link_file "${WINEDIR}/lib/wine/dxvk/${wine_dxvk_dll}.dll" "${WINEPREFIX}/drive_c/windows/syswow64/${wine_dxvk_dll}.dll"
-                try_force_link_file "${WINEDIR}/lib64/wine/dxvk/${wine_dxvk_dll}.dll" "${WINEPREFIX}/drive_c/windows/system32/${wine_dxvk_dll}.dll"
-            else
-                try_force_link_file "${PATH_TO_DXVK_FILES}/x32/${wine_dxvk_dll}.dll" "${WINEPREFIX}/drive_c/windows/syswow64/${wine_dxvk_dll}.dll"
-                try_force_link_file "${PATH_TO_DXVK_FILES}/x64/${wine_dxvk_dll}.dll" "${WINEPREFIX}/drive_c/windows/system32/${wine_dxvk_dll}.dll"
-            fi
+            case "$PW_USE_SUPPLIED_DXVK_VKD3D" in
+                2)
+                    try_force_link_file "${WINEDIR}/lib/wine/dxvk/i386-windows/${wine_dxvk_dll}.dll" "${WINEPREFIX}/drive_c/windows/syswow64/${wine_dxvk_dll}.dll"
+                    try_force_link_file "${WINEDIR}/lib/wine/dxvk/x86_64-windows/${wine_dxvk_dll}.dll" "${WINEPREFIX}/drive_c/windows/system32/${wine_dxvk_dll}.dll" ;;
+                1)
+                    try_force_link_file "${WINEDIR}/lib/wine/dxvk/${wine_dxvk_dll}.dll" "${WINEPREFIX}/drive_c/windows/syswow64/${wine_dxvk_dll}.dll"
+                    try_force_link_file "${WINEDIR}/lib64/wine/dxvk/${wine_dxvk_dll}.dll" "${WINEPREFIX}/drive_c/windows/system32/${wine_dxvk_dll}.dll" ;;
+                0)
+                    try_force_link_file "${PATH_TO_DXVK_FILES}/x32/${wine_dxvk_dll}.dll" "${WINEPREFIX}/drive_c/windows/syswow64/${wine_dxvk_dll}.dll"
+                    try_force_link_file "${PATH_TO_DXVK_FILES}/x64/${wine_dxvk_dll}.dll" "${WINEPREFIX}/drive_c/windows/system32/${wine_dxvk_dll}.dll" ;;
+            esac
             if [[ $PW_USE_FAKE_DLSS_3 == "1" ]] && [[ $wine_dxvk_dll == "dxgi" ]]
             then var_winedlloverride_update "dxgi=n,b"
             else var_winedlloverride_update "${wine_dxvk_dll}=n"
@@ -3970,7 +3976,11 @@ start_portwine () {
 
     if [[ "$DXVK_ENABLE_NVAPI" == "1" ]] ; then
         print_info "Try create symlink NVAPI files..."
-        if [[ $PW_USE_SUPPLIED_DXVK_VKD3D == "1" ]] && [[ -f "${WINEDIR}/lib64/wine/nvapi/nvapi64.dll" ]] ; then
+        if [[ $PW_USE_SUPPLIED_DXVK_VKD3D == "2" ]] && [[ -f "${WINEDIR}/lib/wine/nvapi/x86_64-windows/nvapi64.dll" ]] ; then
+            try_force_link_file "${WINEDIR}/lib/wine/nvapi/i386-windows/nvapi.dll" "${WINEPREFIX}/drive_c/windows/syswow64/nvapi.dll"
+            try_force_link_file "${WINEDIR}/lib/wine/nvapi/x86_64-windows/nvapi64.dll" "${WINEPREFIX}/drive_c/windows/system32/nvapi64.dll"
+            try_force_link_file "${WINEDIR}/lib/wine/nvapi/x86_64-windows/nvofapi64.dll" "${WINEPREFIX}/drive_c/windows/system32/nvofapi64.dll"
+        elif [[ $PW_USE_SUPPLIED_DXVK_VKD3D == "1" ]] && [[ -f "${WINEDIR}/lib64/wine/nvapi/nvapi64.dll" ]] ; then
             try_force_link_file "${WINEDIR}/lib/wine/nvapi/nvapi.dll" "${WINEPREFIX}/drive_c/windows/syswow64/nvapi.dll"
             try_force_link_file "${WINEDIR}/lib64/wine/nvapi/nvapi64.dll" "${WINEPREFIX}/drive_c/windows/system32/nvapi64.dll"
             try_force_link_file "${WINEDIR}/lib64/wine/nvapi/nvofapi64.dll" "${WINEPREFIX}/drive_c/windows/system32/nvofapi64.dll"
@@ -3989,19 +3999,29 @@ start_portwine () {
     if [[ -n "$CP_VKD3D_FILES" ]] ; then
         print_info "Try create symlink VKD3D files..."
         for wine_vkd3d_dll in $CP_VKD3D_FILES ; do
-            if [[ $PW_USE_SUPPLIED_DXVK_VKD3D == "1" ]] ; then
-                if [[ $wine_vkd3d_dll =~ d3d12 ]] ; then
-                    try_force_link_file "${WINEDIR}/lib/wine/vkd3d-proton/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/syswow64/${wine_vkd3d_dll}.dll"
-                    try_force_link_file "${WINEDIR}/lib64/wine/vkd3d-proton/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/system32/${wine_vkd3d_dll}.dll"
-                fi
-                if [[ $wine_vkd3d_dll =~ libvkd3d ]] ; then
-                    try_force_link_file "${WINEDIR}/lib/vkd3d/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/syswow64/${wine_vkd3d_dll}.dll"
-                    try_force_link_file "${WINEDIR}/lib64/vkd3d/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/system32/${wine_vkd3d_dll}.dll"
-                fi
-            else
-                try_force_link_file "${PATH_TO_VKD3D_FILES}/x86/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/syswow64/${wine_vkd3d_dll}.dll"
-                try_force_link_file "${PATH_TO_VKD3D_FILES}/x64/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/system32/${wine_vkd3d_dll}.dll"
-            fi
+            case "$PW_USE_SUPPLIED_DXVK_VKD3D" in
+                2)
+                    if [[ $wine_vkd3d_dll =~ d3d12 ]] ; then
+                        try_force_link_file "${WINEDIR}/lib/wine/vkd3d-proton/i386-windows/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/syswow64/${wine_vkd3d_dll}.dll"
+                        try_force_link_file "${WINEDIR}/lib/wine/vkd3d-proton/x86_64-windows/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/system32/${wine_vkd3d_dll}.dll"
+                    fi
+                    if [[ $wine_vkd3d_dll =~ libvkd3d ]] ; then
+                        try_force_link_file "${WINEDIR}/lib/vkd3d/i386-windows/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/syswow64/${wine_vkd3d_dll}.dll"
+                        try_force_link_file "${WINEDIR}/lib/vkd3d/x86_64-windows/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/system32/${wine_vkd3d_dll}.dll"
+                    fi ;;
+                1)
+                    if [[ $wine_vkd3d_dll =~ d3d12 ]] ; then
+                        try_force_link_file "${WINEDIR}/lib/wine/vkd3d-proton/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/syswow64/${wine_vkd3d_dll}.dll"
+                        try_force_link_file "${WINEDIR}/lib64/wine/vkd3d-proton/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/system32/${wine_vkd3d_dll}.dll"
+                    fi
+                    if [[ $wine_vkd3d_dll =~ libvkd3d ]] ; then
+                        try_force_link_file "${WINEDIR}/lib/vkd3d/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/syswow64/${wine_vkd3d_dll}.dll"
+                        try_force_link_file "${WINEDIR}/lib64/vkd3d/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/system32/${wine_vkd3d_dll}.dll"
+                    fi ;;
+                0)
+                    try_force_link_file "${PATH_TO_VKD3D_FILES}/x86/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/syswow64/${wine_vkd3d_dll}.dll"
+                    try_force_link_file "${PATH_TO_VKD3D_FILES}/x64/${wine_vkd3d_dll}.dll" "${WINEPREFIX}/drive_c/windows/system32/${wine_vkd3d_dll}.dll" ;;
+            esac
             var_winedlloverride_update "${wine_vkd3d_dll}=n"
         done
         create_new_dir "${PATH_TO_VKD3D_FILES}/vkd3d_cache"


### PR DESCRIPTION
1) Добавил поддержку Proton 10 для supplied dxvk vkd3d
2) С supplied dxvk vkd3d по умолчанию используется export DXVK_ASYNC="1" (если  вдруг поддержки async нет, по идее переменная ни что влиять не должна)
3) Пофиксил ошибку из-за которой на Proton 10 не работали некоторые игры (из-за того что библиотеки libvkd3d использовались как натив) ,проверил старые версии vkd3d, им для работы не нужно чтобы libvkd3d использовался в wine в качестве нативных библиотек
![Снимок экрана_20250520_070845](https://github.com/user-attachments/assets/b9b8e09d-e243-4aea-b438-41f247de853c)
