### PR TITLE
fix: Take first PID from pgrep for EGS

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -4593,11 +4593,11 @@ portwine_launch () {
         while true ; do
             sleep 5
             if [[ -z "$GAMEPID" ]] ; then
-                GAMEPID="$(pgrep -fa 'EpicPortal|epicusername|epiclocale|AUTH_LOGIN' | awk '{print $1}')"
+                GAMEPID="$(pgrep -fa 'EpicPortal|epicusername|epiclocale|AUTH_LOGIN' | awk '{print $1}' | head -n 1)"
             else
                 if waitpid "$GAMEPID" ; then
                     sleep 1
-                    GAMEPID="$(pgrep -fa 'EpicPortal|epicusername|epiclocale|AUTH_LOGIN' | awk '{print $1}')"
+                    GAMEPID="$(pgrep -fa 'EpicPortal|epicusername|epiclocale|AUTH_LOGIN' | awk '{print $1}' | head -n 1)"
                     [[ -z "$GAMEPID" ]] && break || continue
                 fi
             fi


### PR DESCRIPTION
Поправил баг с отслеживанием процессов EGS. Теперь берем только первый PID из списка