### PR TITLE
refactor: rewrite check_nvidia_rtx to identify RTX cards by excluding non-RTX patterns

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -2297,14 +2297,18 @@ check_dirs_and_files_in_pfx () {
 
 check_nvidia_rtx () {
     if [[ "$LSPCI_VGA" == *nvidia* ]] ; then
-        # Turing (without nvidia 16XX)
-        [[ "$LSPCI_VGA" == *TU[0-9]* ]] && [[ "$LSPCI_VGA" != *TU11[6-7]* ]] && return 0
-        # Ampere
-        [[ "$LSPCI_VGA" == *GA[0-9]* ]] && return 0
-        # Ada_Lovelace
-        [[ "$LSPCI_VGA" == *AD[0-9]* ]] || [[ "$LSPCI_VGA" == *2[6-8][0-9]* ]] && return 0
-        # Blackwell and Blackwell 2.0
-        [[ "$LSPCI_VGA" == *GB[0-9]* ]] && return 0
+        if [[ "$LSPCI_VGA" == *G[0-9]* ]] ||
+           [[ "$LSPCI_VGA" == *GT[0-9]* ]] ||
+           [[ "$LSPCI_VGA" == *MCP[0-9]* ]] ||
+           [[ "$LSPCI_VGA" == *GF[0-9]* ]] ||
+           [[ "$LSPCI_VGA" == *GK[0-9]* ]] ||
+           [[ "$LSPCI_VGA" == *GM[0-9]* ]] ||
+           [[ "$LSPCI_VGA" == *GP[0-9]* ]] ||
+           [[ "$LSPCI_VGA" == *GV[0-9]* ]] ||
+           [[ "$LSPCI_VGA" == *TU11[6-7]* ]]; then
+            return 1
+        fi
+        return 0
     fi
     return 1
 }


### PR DESCRIPTION
Прошлая реализация с возразращением true на rtx карты и false на всё остальное была неудобна тем что для того что бы добавить новую карту приходилось доставать pciid из nouveau, а он на несколько месяцев опаздывает, в случае с Blackwell было месяца два - три, плюс pciid который не следует общему шаблону как "$LSPCI_VGA" == *2[6-8][0-9]*, я подумал что проще будет взять все старые карты где нет rtx возращать на них false и потом true на всё остальное pciid старых карт давно известны и не требуют проверки или обновления, соответвенно при выходе какой нибудь rtx 60 ничего делать не придётся код просто по умолчанию будет её поддерживать