### PR TITLE
Prefer ppdb settings over user.conf

### DIFF
--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -346,6 +346,9 @@ if [[ ${portwine_exe,,} =~ (setup|install|.msi$) ]] ; then
     export PW_USE_SETUP_FILE="1"
 fi
 
+# shellcheck source=/dev/null
+source "${USER_CONF}"
+
 pw_init_db
 
 if [[ ! -d "${HOME}/PortProton" ]] \
@@ -355,9 +358,6 @@ then
 fi
 
 pw_check_and_download_dxvk_and_vkd3d
-
-# shellcheck source=/dev/null
-source "${USER_CONF}"
 
 if [[ "${SKIP_CHECK_UPDATES}" != 1 ]] ; then
     kill_portwine


### PR DESCRIPTION
По задумке разве у ppdb  не должен быть высший приоритет по переопределению настроек ?
Например в user.conf указано PW_USE_NATIVE_WAYLAND=1 (типа по умолчанию пусть будет включено), тогда нельзя для конкретной одной игры его выключить если она с ним не работает.
Тоже самое с PW_WINE_USE, но это обходится через PW_PROTON_LG_VER (там можно любую версию указать, в том числе GE-Proton)