### PR TITLE
Correct display of logical_cores when the number of cores is less than 4

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -2870,8 +2870,8 @@ pw_skip_get_info () {
         fi
 
         logical_cores=$(grep -c ^"processor" /proc/cpuinfo)
-        if [[ "${logical_cores}" -le "4" ]] ; then
-            GET_LOGICAL_CORE="1!$(seq -s! 1 $(( logical_cores - 1 )))"
+        if (( $logical_cores <= "4" )) ; then
+            GET_LOGICAL_CORE="$(seq -s! 1 $(( logical_cores - 1 )))"
         else
             GET_LOGICAL_CORE="1!2!$(seq -s! 4 4 $(( logical_cores - 1 )))"
         fi


### PR DESCRIPTION
https://github.com/Castro-Fidel/PortWINE/issues/523 Настройка некорректно отображается, когда 2 ядра в системе