### PR TITLE
start_activity_simulation: Added support for fedora, reduce time sleep

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -136,13 +136,20 @@ fatal () {
 }
 
 start_activity_simulation() {
+    grep -i "fedora" "/run/host/etc/os-release" &>/dev/null && START_ACTIVITY_FEDORA="1"
     (
         trap 'exit 0' TERM INT
         while [[ -f "${PORT_WINE_PATH}/data/tmp/screensaver_pid" ]] ; do
-            dbus-send --session --dest=org.freedesktop.ScreenSaver \
-                      --type=method_call /org/freedesktop/ScreenSaver \
-                      org.freedesktop.ScreenSaver.SimulateUserActivity
-            sleep 30
+            if [[ $START_ACTIVITY_FEDORA == "1" ]] ; then
+                gdbus call --session --dest org.freedesktop.ScreenSaver \
+                           --object-path /ScreenSaver \
+                           --method org.freedesktop.ScreenSaver.SimulateUserActivity
+            else
+                dbus-send --session --dest=org.freedesktop.ScreenSaver \
+                          --type=method_call /org/freedesktop/ScreenSaver \
+                          org.freedesktop.ScreenSaver.SimulateUserActivity
+            fi
+            sleep 29
         done
     ) &
     echo $! > "${PORT_WINE_PATH}/data/tmp/screensaver_pid"


### PR DESCRIPTION
1) dbus-send не работает на федоре, только с gdbus call.
2) Уменьшил sleep с 30 до 29, если затухание экрана стоит 30, то на 0.1-0.2 секунды происходят мерцания (на ноутбуке точно)