### PR TITLE
resize_png: fixes bug for RESIZE_NAME_PNG

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -6601,6 +6601,10 @@ resize_png () {
         RESIZE_NAME_PNG="${2// /_}"
     fi
 
+    if [[ $RESIZE_NAME_PNG =~ ru.linux_gaming.PortProton/data/img/ ]]
+    then RESIZE_NAME_PNG=${RESIZE_NAME_PNG/*ru.linux_gaming.PortProton\/data\/img\//}
+    fi
+
     for resize_to in "${@:3}" ; do
         if [[ $resize_to == 128 ]]
         then resize_to_helper=""


### PR DESCRIPTION
Исправлен баг для RESIZE_NAME_PNG, смысл бага заключается в том, если удалить PortProton из Flatpak и поверх него установить в ту же директорию нативный PortProton, то функция resize_png будет работать некорректно, каждый раз используя exe-thumbnailer

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8c4446c1-a35e-44ab-a2c9-4ff108dcf971" />
