### PR TITLE
Fixes for systemd-inhibit

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -3696,7 +3696,7 @@ if [[ "$GAMEMODERUN" != "1" ]]; then
         start_activity_simulation
         PW_INHIBIT_SLR=""
         print_info "Screensaver will be inhibited using D-Bus (Flatpak mode)"
-    elif command -v systemd-inhibit &>/dev/null; then
+    elif [[ -e "/var/run/dbus/system_bus_socket" ]] && command -v systemd-inhibit &>/dev/null; then
         PW_INHIBIT_SLR="systemd-inhibit --mode=block --who=ru.linux_gaming.PortProton --why=${translations[Launched]} --what=idle:sleep"
         print_info "Screensaver will be inhibited using systemd-inhibit (Native mode)"
     fi


### PR DESCRIPTION
systemd-inhibit крашит PortProton, если нет доступа к /var/run/dbus/system_bus_socket, проверить можно если сделать к примеру sudo rm -f /var/run/dbus/system_bus_socket, и потом через PortProton запустить какое-нибудь приложение/игру. 