### PR TITLE
Fixed long startup of setup files

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -1002,6 +1002,7 @@ fix_icon_name_png () {
 # Поиск нужного .desktop файла по $portwine_exe (для показа в комментариях нужного времени)
 # Параллельное создание базы по времени после завершения приложения
 search_desktop_file () {
+    [[ $PW_USE_SETUP_FILE == "1" ]] && return 0
     local desktop_file desktop_file_new line1 line2 FILE_SHA256SUM_ARRAY EXEC_DESKTOP ICON_NAME BROKEN_LINE FILE_SHA256SUM_FOUND FILE_SHA256SUM_NOT_FOUND
     if [[ -z $FILE_SHA256SUM ]] ; then
         read -r -a FILE_SHA256SUM_ARRAY < <(sha256sum "$portwine_exe")


### PR DESCRIPTION
Для setup файлов search_desktop_file не нужен, потому что он используется для поиска уже существующих .desktop файлов PortProton'a, и для создания, изменений, получения информации из статистики. (setup файлам это не нужно), а так из-за того что в search_desktop_file используется sha256sum и бывает такое то что setup файлы могут весить много (от 1 гб и больше) , то процесс запуска становится в конечном итоге из-за этого долгим.