### PR TITLE
Use compare_versions for glibc

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -5625,7 +5625,7 @@ gui_edit_db () {
     [[ ! -e "/dev/ntsync" ]] && DISABLE_EDIT_DB_LIST+=" PW_USE_NTSYNC"
 
     if ! check_flatpak \
-    && [[ $(ldd --version | head -n 1 | awk '{print $4}') < 2.38 ]]
+    && ! compare_versions "$(ldd --version | head -n 1 | awk '{print $4}')" "2.38"
     then
         DISABLE_EDIT_DB_LIST+=" PW_USE_LS_FRAME_GEN"
         export PW_USE_LS_FRAME_GEN="0"


### PR DESCRIPTION
compare_versions более точно определяет разницу между версиями. К примеру compare_versions "1.11" "1.11" и compare_versions "1.12" "1.11" будет истина, так как в первом случае первое число равно второму, а во втором первое больше второго. (равно и больше) По этому если использовать ! compare_versions "1.11" "1.11" , это будет ложь, ! compare_versions "1.12" "1.11" будет тоже ложь, а  ! compare_versions "1.10" "1.11" будет истина (так как ! используется отрицание функции), что соответствует знаку < (строго меньше)