### PR TITLE
Trim whitespace when parsing SteamAppId

### DIFF
--- a/data_from_portwine/scripts/add_in_steam.sh
+++ b/data_from_portwine/scripts/add_in_steam.sh
@@ -86,7 +86,7 @@ getSteamId() {
 			local file=$(find "$(dirname "${NOSTAPPPATH}")" -type f \( ${conditions# -o} \) -print -quit 2>/dev/null)
 			if [[ -n "${file}" ]]; then
 				if [[ "${file}" == *"steam_appid.txt" ]]; then
-					SteamAppId=$(cat "${file}" | tr -d '\r\n')
+					SteamAppId=$(cat "${file}" | tr -d '[:space:]\r\n')
 				else
 					SteamAppId=$(grep -i "^AppId=" "${file}" | cut -d'=' -f2 | head -1 | tr -d '\r\n')
 				fi


### PR DESCRIPTION
Заметил что в файлах steam_appid.txt бывают пробелы изза чего бывали ситуации когда не получались обложки