### PR TITLE
Added: pw_check_vulkan_extensions function

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -718,7 +718,7 @@ var_vkd3d_config_update () {
 var_radv_perftest_config_update () {
     if echo "$RADV_PERFTEST" | grep "$1"
     then return 0
-    else export RADV_PERFTEST="${1}${RADV_PERFTEST:+;$RADV_PERFTEST}"
+    else export RADV_PERFTEST="${1}${RADV_PERFTEST:+,$RADV_PERFTEST}"
     fi
 }
 
@@ -2800,6 +2800,13 @@ pw_check_vulkan () {
     fi
 }
 
+pw_check_vulkan_extensions () {
+    if sed -n "/deviceName \+ = $PW_GPU_USE/,/GPU/p" "${PW_TMPFS_PATH}/vulkaninfo.tmp" | grep -w "$1" &>/dev/null
+    then return 0
+    else return 1
+    fi
+}
+
 compare_versions () {
     IFS='.' read -ra a1 <<< "$1"
     IFS='.' read -ra a2 <<< "$2"
@@ -3727,7 +3734,12 @@ start_portwine () {
 
     if [[ "${PW_USE_RAY_TRACING}" == "1" ]] ; then
         var_vkd3d_config_update dxr
-        var_radv_perftest_config_update rt
+        if [[ $(check_vendor_gpu) == "amd" ]] ; then
+            var_radv_perftest_config_update rt
+            if ! pw_check_vulkan_extensions "VK_KHR_ray_tracing_pipeline" ; then
+                var_radv_perftest_config_update emulate_rt
+            fi
+        fi
     else
         var_vkd3d_config_update nodxr
     fi
@@ -4626,7 +4638,7 @@ fi
         if [[ $(check_vendor_gpu) == "amd" ]] ; then
             export RADV_DEBUG+="nodcc "
             export AMD_DEBUG="nodcc"
-            if [[ ! $(<"${PW_TMPFS_PATH}/vulkaninfo.tmp") =~ VK_EXT_image_drm_format_modifier ]] ; then
+            if ! pw_check_vulkan_extensions "VK_EXT_image_drm_format_modifier" ; then
                 export R600_DEBUG="nodcc"
                 grep -e '--backend' "${PW_TMPFS_PATH}/gamescope.tmp" &>/dev/null && PW_GS_BACKEND_SDL="1"
             fi


### PR DESCRIPTION
1) RADV_PERFTEST= перечисление должно быть через , (запятую) а не через ;
2) Добавил функцию pw_check_vulkan_extensions, чем она отличается к примеру от текущего

if [[ ! $(<"${PW_TMPFS_PATH}/vulkaninfo.tmp") =~ VK_EXT_image_drm_format_modifier ]] ; then - здесь мы

VK_EXT_image_drm_format_modifier смотрим во всём файле, а в vulkaninfo могут быть несколько драйверов (тот же llvmpipe), другие видеокарты, а c pw_check_vulkan_extensions проверка проходит только на ту карту, которая используется именно в $PW_GPU_USE (то есть расширения с других устройств влиять как-либо не будут)

3) Добавил новый параметр emulate_rt, если карта по умолчанию не поддерживает raytracing, то он его включит (на vega 7 проверил, работает, так же должен работать на дискретных картах). 