### PR TITLE
Fix GLIBC version check

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -5673,7 +5673,7 @@ gui_edit_db () {
     [[ ! -e "/dev/ntsync" ]] && DISABLE_EDIT_DB_LIST+=" PW_USE_NTSYNC"
 
     if ! check_flatpak \
-    && ! compare_versions "$(ldd --version | head -n 1 | awk '{print $5}')" "2.38"
+    && ! compare_versions "$(ldd --version | head -n 1 | awk '{print $NF}')" "2.38"
     then
         DISABLE_EDIT_DB_LIST+=" PW_USE_LS_FRAME_GEN"
         export PW_USE_LS_FRAME_GEN="0"

--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -5673,7 +5673,7 @@ gui_edit_db () {
     [[ ! -e "/dev/ntsync" ]] && DISABLE_EDIT_DB_LIST+=" PW_USE_NTSYNC"
 
     if ! check_flatpak \
-    && ! compare_versions "$(ldd --version | head -n 1 | awk '{print $4}')" "2.38"
+    && ! compare_versions "$(ldd --version | head -n 1 | awk '{print $5}')" "2.38"
     then
         DISABLE_EDIT_DB_LIST+=" PW_USE_LS_FRAME_GEN"
         export PW_USE_LS_FRAME_GEN="0"


### PR DESCRIPTION
После обновления перестали открываться настройки. Вылетает с ошибкой

> /mnt/M.2/Games/PortProton/data/scripts/functions_helper: строка 2817: 42-0ubuntu1: слишком большое значение для основания (неверный маркер «0ubuntu1»)

```
$ ldd --version
ldd (Ubuntu GLIBC 2.42-0ubuntu1) 2.42
...
```