### PR TITLE
Fixes: Automatic added fix for unity games

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -2473,7 +2473,7 @@ pw_init_db () {
         if [[ "${PW_WINE_CPU_TOPOLOGY}" == "disabled" ]] && [[ -n "${WINE_CPU_TOPOLOGY}" ]] ; then
             export PW_WINE_CPU_TOPOLOGY="${WINE_CPU_TOPOLOGY}"
         fi
-        if lsbash "${PATH_TO_GAME}"/*_Data/Resources/ --grep "unity" &>/dev/null \
+        if compgen -G "${PATH_TO_GAME}/*_Data/Resources/*unity*" &>/dev/null \
         && [[ "${PW_WINE_CPU_TOPOLOGY}" == "disabled" ]] \
         && [[ $(grep -c ^"processor" /proc/cpuinfo) -gt "8" ]]
         then


### PR DESCRIPTION
lsbash криво работает когда есть звёздочка (которая подразумевает любые цифры, буквы и т.д.), точнее вообще так не работает. Заменил на более надёжный compgen -G (встроенная команда у bash)