### PR TITLE
CLI fixes for PPQT

### DIFF
--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -492,7 +492,7 @@ $(echo $files_from_autoinstall | awk '{for (i = 1; i <= NF; i++) {if (i % 10 == 
         ;;
     --clear_pfx)
         get_wine_and_pfx "$2" "$3"
-        clear_pfx
+        pw_clear_pfx
         exit $?
         ;;
     --initial)


### PR DESCRIPTION
Первый коммит фиксит

 Info: Try create symlink DXVK files... 
mkdir: невозможно создать каталог «/dxvk_cache»: Отказано в доступе
 Info: Try create symlink VKD3D files... 
mkdir: невозможно создать каталог «/vkd3d_cache»: Отказано в доступе

Второй коммит просто исправление опечатки из-за которой clear_pfx всё таки пришлось переизобрести 