### PR TITLE
fix: correct file extension regex matching

### DIFF
--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -59,11 +59,11 @@ if [[ ${1,,} == "cli" ]] ; then
 fi
 check_variables PW_CLI "0"
 
-if [[ "${1,,}" =~ .ppack$ ]] ; then
+if [[ "${1,,}" =~ \.ppack$ ]] ; then
     export PW_NO_RESTART_PPDB="1"
     export PW_DISABLED_CREATE_DB="1"
     portwine_exe="$1"
-elif [[ "${1,,}" =~ .(exe|bat|msi|reg|lnk)$ ]] ; then
+elif [[ "${1,,}" =~ \.(exe|bat|msi|reg|lnk)$ ]] ; then
     if [[ -f "$1" ]] ; then
         portwine_exe="$(realpath -s "$1")"
     elif [[ -f "$OLDPWD/$1" ]] ; then
@@ -72,11 +72,11 @@ elif [[ "${1,,}" =~ .(exe|bat|msi|reg|lnk)$ ]] ; then
         portwine_exe="$1"
         MISSING_DESKTOP_FILE="1"
     fi
-    if [[ -n "${portwine_exe}" && "${1,,}" =~ .lnk$ ]] ; then
+    if [[ -n "${portwine_exe}" && "${1,,}" =~ \.lnk$ ]] ; then
         get_lnk "${portwine_exe}"
         portwine_exe="$(realpath "${link_path}" 2>/dev/null)"
     fi
-elif [[ "$1" =~ ^--(debug|launch|edit-db)$ && "${2,,}" =~ .(exe|bat|msi|reg)$ ]] ; then
+elif [[ "$1" =~ ^--(debug|launch|edit-db)$ && "${2,,}" =~ \.(exe|bat|msi|reg)$ ]] ; then
     if [[ -f "$2" ]] ; then
         portwine_exe="$(realpath -s "$2")"
     elif [[ -f "$OLDPWD/$2" ]] ; then


### PR DESCRIPTION
Escaped dots in regex patterns to match actual file extensions. Prevents false positives like '--regedit' matching the '.reg' pattern.