### PR TITLE
fix(--show-ppdb): account for var and user.conf variables

### DIFF
--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -547,18 +547,37 @@ ${translations[Usage examples:]}
             pw_init_db
         fi
 
-        grep -E '^export ' "$ppdb_path" \
-        | sed '/^[[:space:]]*$/d' \
-        | while IFS= read -r line; do
-            line="${line#export }"
-            if [[ "$line" =~ ^([^=]+)=\"([^\"]*)\"[[:space:]]*#.*$ ]]; then
-                echo "${BASH_REMATCH[1]}=\"${BASH_REMATCH[2]}\""
-            elif [[ "$line" =~ ^([^=]+)=([^#[:space:]]+)[[:space:]]*#.*$ ]]; then
-                echo "${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"
-            else
-                echo "$line"
+        declare -A all_vars
+        while IFS='=' read -r key val; do
+            key="${key#export }"
+            val="${val#\"}"
+            val="${val%\"}"
+            all_vars["$key"]="$val"
+        done < <(grep -E '^export ' "$ppdb_path" | sed '/^[[:space:]]*$/d')
+
+        check_user_conf
+        if [[ -f "$USER_CONF" ]]; then
+            while IFS='=' read -r key val; do
+                key="${key#export }"
+                val="${val#\"}"
+                val="${val%\"}"
+                all_vars["$key"]="$val"
+            done < <(grep -E '^export ' "$USER_CONF" 2>/dev/null | sed '/^[[:space:]]*$/d')
+        fi
+
+        while IFS='=' read -r key val; do
+            key="${key#export }"
+            val="${val#\"}"
+            val="${val%\"}"
+            if [[ -z "${all_vars[$key]+x}" ]]; then
+                all_vars["$key"]="$val"
             fi
+        done < <(grep -E '^export ' "$PORT_SCRIPTS_PATH/var" | sed '/^[[:space:]]*$/d')
+
+        for key in "${!all_vars[@]}"; do
+            echo "${key}=\"${all_vars[$key]}\""
         done
+
         exit 0
         ;;
     --backup-prefix)


### PR DESCRIPTION
Переделал функцию --show-ppdb что бы она показывала и var и user.conf тоже, потому что pw_init_db делает такой PPDB

#!/usr/bin/env bash
#Author: barry
#DRG Survivor.exe
#Rating=1-5
export PW_WINE_USE="PROTON_LG"
export PW_PREFIX_NAME="DEFAULT"
export PW_VULKAN_USE="6"

И в итоге в настройках PPQt гордая пустота ), решил это поправить, настройки работают по приоритету user.conf > ppdb > var, ещё убрал башизмы что бы это не сломалось на каком нибудь dash