### PR TITLE
 refactor(gamescope): store GUI settings in PW_GAMESCOPE_ARGS_NEW only 

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -4619,7 +4619,7 @@ fi
         fi
     fi
 
-    unset PW_GAMESCOPE_ARGS_NEW PW_GAMESCOPE_VARIABLES_BEFORE PW_GAMESCOPE_VARIABLES_AFTER
+    unset PW_GAMESCOPE_VARIABLES_BEFORE PW_GAMESCOPE_VARIABLES_AFTER
     # GAMESCOPE fixes:
     if [[ "${PW_GAMESCOPE}" == "1" && "${GAMESCOPE_INSTALLED}" == "1" ]] \
     || check_gamescope_session
@@ -4649,71 +4649,20 @@ fi
         then PW_ID_VIDEO=" --prefer-vk-device ${PW_vendorID}:${PW_deviceID}"
         fi
 
-        #checkbox
-        [[ "${PW_GS_FULLSCREEN}" == "1" ]] && PW_GAMESCOPE_ARGS_NEW+=" -f"
-        [[ "${PW_GS_FORCE_FULLSCREEN}" == "1" ]] && PW_GAMESCOPE_ARGS_NEW+=" --force-windows-fullscreen"
-        [[ "${PW_GS_BORDERLESS_WINDOW}" == "1" ]] &&  PW_GAMESCOPE_ARGS_NEW+=" -b"
-        [[ "${PW_GS_FORCE_GRAB_CURSOR}" == "1" ]] && PW_GAMESCOPE_ARGS_NEW+=" --force-grab-cursor"
-        [[ "${PW_GS_FORCE_GRAB_KEYBOARD}" == "1" ]] && PW_GAMESCOPE_ARGS_NEW+=" -g"
-        [[ "${PW_GS_HDR_ENABLE}" == "1" ]] && PW_GAMESCOPE_ARGS_NEW+=" --hdr-enabled"
         [[ "${PW_GS_ENABLE_GAMESCOPE_WSI}" == "1" ]] && export ENABLE_GAMESCOPE_WSI="1"
-        [[ "${PW_GS_HDR_ITM_ENABLE}" == "1" ]] && PW_GAMESCOPE_ARGS_NEW+=" --hdr-itm-enable"
-        [[ "${PW_GS_SDR_GAMMUT_WIDENESS}" == "1" ]] && PW_GAMESCOPE_ARGS_NEW+=" --sdr-gamut-wideness"
-        [[ "${PW_GS_FORCE_COMPOSITION}" == "1" ]] && PW_GAMESCOPE_ARGS_NEW+=" --force-composition"
-        [[ "${PW_GS_HDR_FORCE_SUPPORT}" == "1" ]] && PW_GAMESCOPE_ARGS_NEW+=" --hdr-debug-force-support"
-        [[ "${PW_GS_HDR_FORCE_OUTPUT}" == "1" ]] && PW_GAMESCOPE_ARGS_NEW+=" --hdr-debug-force-output"
-        [[ "${PW_GS_HDR_FORCE_HEATMAP}" == "1" ]] && PW_GAMESCOPE_ARGS_NEW+=" --hdr-debug-heatmap"
-        [[ "${PW_GS_EXPOSE_WAYLAND}" == "1" ]] && PW_GAMESCOPE_ARGS_NEW+=" --expose-wayland"
-        [[ "${PW_GS_REALTIME_SCHEDULING}" == "1" ]] && PW_GAMESCOPE_ARGS_NEW+=" --rt"
-
-        if [[ "${PW_GS_MANGOAPP}" == "1" ]] ; then
-            PW_GAMESCOPE_ARGS_NEW+=" --mangoapp"
-            export PW_MANGOHUD="0"
-        fi
-
-        [[ "${PW_GS_BACKEND_SDL}" == "1" ]] && PW_GAMESCOPE_ARGS_NEW+=" --backend sdl"
         [[ "${PW_GS_SDL_VIDEODRIVER_X11}" == "1" ]] && export SDL_VIDEODRIVER="x11"
-        [[ "${PW_GS_CURSOR_SCALE_HEIGHT}" == "1" ]] && PW_GAMESCOPE_ARGS_NEW+=" --cursor-scale-height 1"
-
-        #combobox
-        if [[ "${PW_GS_SHOW_RESOLUTION}" != "disabled" ]] ; then
-            PWGSRESSW1="${PW_GS_SHOW_RESOLUTION%x*}"
-            PWGSRESSW="${PWGSRESSW1%%-*}"
-            PWGSRESSH1="${PW_GS_SHOW_RESOLUTION#*x}"
-            PWGSRESSH="${PWGSRESSH1%%-*}"
-            PW_GAMESCOPE_ARGS_NEW+=" -W ${PWGSRESSW} -H ${PWGSRESSH}"
-
-            if [[ "${PW_GS_INTERNAL_RESOLUTION}" != "0.0" ]] ; then
-                GS_RES_W=${PW_GS_SHOW_RESOLUTION:0:4}
-                GS_RES_H=${PW_GS_SHOW_RESOLUTION:5:8}
-                PWGSRESIW=$(echo "${GS_RES_W}" "${PW_GS_INTERNAL_RESOLUTION}" | awk '{print $1*$2}')
-                PWGSRESIH=$(echo "${GS_RES_H}" "${PW_GS_INTERNAL_RESOLUTION}" | awk '{print $1*$2}')
-                PW_GAMESCOPE_ARGS_NEW+=" -w ${PWGSRESIW} -h ${PWGSRESIH}"
-            fi
+        [[ "${PW_GS_MANGOAPP}" == "1" ]] && export PW_MANGOHUD="0"
+        if [[ "${PW_GS_HDR_ENABLE}" == "1" && "${PW_GS_ENABLE_GAMESCOPE_WSI}" == "1" ]] ; then
+            export ENABLE_HDR_WSI="1"
+            export DXVK_HDR="1"
+            export GAMESCOPE_WAYLAND_DISPLAY="gamescope-0"
         fi
 
-        [[ "${PW_GS_FRAME_LIMIT}" != "disabled" ]] && PW_GAMESCOPE_ARGS_NEW+=" -r ${PW_GS_FRAME_LIMIT}"
-        [[ "${PW_GS_MAX_SCALE_FACTOR}" != "0.0" ]] && PW_GAMESCOPE_ARGS_NEW+=" -m ${PW_GS_MAX_SCALE_FACTOR}"
-        [[ "${PW_GS_SCALER_MODE}" != "disabled" ]] && PW_GAMESCOPE_ARGS_NEW+=" -S ${PW_GS_SCALER_MODE}"
-
-        if [[ "${PW_GS_FILTER_MODE}" != "disabled" ]] ; then
-            export PW_WINE_FULLSCREEN_FSR="0"
-            if [[ "${PW_GS_FILTER_MODE_OLD}" != "true" ]] ; then
-                PW_GAMESCOPE_ARGS_NEW+=" -F ${PW_GS_FILTER_MODE}"
-            else
-                if [[ "${PW_GS_FILTER_MODE}" == "fsr" ]] ; then
-                    PW_GAMESCOPE_ARGS_NEW+=" -U"
-                elif [[ "${PW_GS_FILTER_MODE}" == "nis" ]] ; then
-                    PW_GAMESCOPE_ARGS_NEW+=" -Y"
-                fi
-            fi
-            PW_GAMESCOPE_ARGS_NEW+=" --sharpness ${PW_GS_UPSCALE_SHARPNESS}"
+        # GUI state lives in PW_GS_*; rebuild args for old/empty profiles.
+        if [[ -z "${PW_GAMESCOPE_ARGS_NEW// }" ]] ; then
+            pw_gamescope_build_args
+            [[ -n "${PW_GS_FILTER_MODE}" && "${PW_GS_FILTER_MODE}" != "disabled" ]] && export PW_WINE_FULLSCREEN_FSR="0"
         fi
-
-        [[ "${PW_GS_MOUSE_SENSITIVITY}" != "0.0" ]] && PW_GAMESCOPE_ARGS_NEW+=" -s ${PW_GS_MOUSE_SENSITIVITY}"
-        [[ "${PW_GS_SDR_CONTENT_NITS}" != "400" ]] && PW_GAMESCOPE_ARGS_NEW+=" --hdr-sdr-content-nits ${PW_GS_SDR_CONTENT_NITS}"
-        [[ "${PW_GS_ITM_SDR_NITS}" != "0" ]] && PW_GAMESCOPE_ARGS_NEW+=" --hdr-itm-sdr-nits ${PW_GS_ITM_SDR_NITS}"
-        [[ "${PW_GS_ITM_TARGET_NITS}" != "0" ]] && PW_GAMESCOPE_ARGS_NEW+=" --hdr-itm-target-nits ${PW_GS_ITM_TARGET_NITS}"
 
         edit_db_from_gui PW_GAMESCOPE_ARGS_NEW
         export PW_RUN_GAMESCOPE="env ${PW_GAMESCOPE_VARIABLES_BEFORE}gamescope${PW_ID_VIDEO}${PW_GAMESCOPE_ARGS_NEW} env ${PW_GAMESCOPE_VARIABLES_AFTER}--"
@@ -6336,9 +6285,245 @@ gui_dgvoodoo2 () {
     restart_pp
 }
 
+# Build gamescope args from current GUI variables.
+pw_gamescope_build_args () {
+    local -a gs_toggle_order=(
+    PW_GS_FULLSCREEN PW_GS_FORCE_FULLSCREEN PW_GS_BORDERLESS_WINDOW PW_GS_FORCE_GRAB_CURSOR
+    PW_GS_FORCE_GRAB_KEYBOARD PW_GS_HDR_ENABLE PW_GS_HDR_ITM_ENABLE PW_GS_SDR_GAMMUT_WIDENESS
+    PW_GS_FORCE_COMPOSITION PW_GS_HDR_FORCE_SUPPORT PW_GS_HDR_FORCE_OUTPUT PW_GS_HDR_FORCE_HEATMAP
+    PW_GS_EXPOSE_WAYLAND PW_GS_REALTIME_SCHEDULING PW_GS_MANGOAPP PW_GS_BACKEND_SDL PW_GS_CURSOR_SCALE_HEIGHT
+    )
+    local -A gs_toggle_map=(
+    [PW_GS_FULLSCREEN]="-f"
+    [PW_GS_FORCE_FULLSCREEN]="--force-windows-fullscreen"
+    [PW_GS_BORDERLESS_WINDOW]="-b"
+    [PW_GS_FORCE_GRAB_CURSOR]="--force-grab-cursor"
+    [PW_GS_FORCE_GRAB_KEYBOARD]="-g"
+    [PW_GS_HDR_ENABLE]="--hdr-enabled"
+    [PW_GS_HDR_ITM_ENABLE]="--hdr-itm-enabled"
+    [PW_GS_SDR_GAMMUT_WIDENESS]="--sdr-gamut-wideness"
+    [PW_GS_FORCE_COMPOSITION]="--force-composition"
+    [PW_GS_HDR_FORCE_SUPPORT]="--hdr-debug-force-support"
+    [PW_GS_HDR_FORCE_OUTPUT]="--hdr-debug-force-output"
+    [PW_GS_HDR_FORCE_HEATMAP]="--hdr-debug-heatmap"
+    [PW_GS_EXPOSE_WAYLAND]="--expose-wayland"
+    [PW_GS_REALTIME_SCHEDULING]="--rt"
+    [PW_GS_MANGOAPP]="--mangoapp"
+    [PW_GS_BACKEND_SDL]="--backend sdl"
+    [PW_GS_CURSOR_SCALE_HEIGHT]="--cursor-scale-height 1"
+    )
+    local gs_var pwgs_res_sw1 pwgs_res_sw pwgs_res_sh1 pwgs_res_sh
+    local gs_res_w gs_res_h pwgs_res_iw pwgs_res_ih
+
+    PW_GAMESCOPE_ARGS_NEW=""
+    for gs_var in "${gs_toggle_order[@]}" ; do
+        [[ "${!gs_var}" == "1" ]] && PW_GAMESCOPE_ARGS_NEW+=" ${gs_toggle_map[$gs_var]}"
+    done
+
+    if [[ -n "${PW_GS_SHOW_RESOLUTION}" && "${PW_GS_SHOW_RESOLUTION}" != "disabled" ]] ; then
+        pwgs_res_sw1="${PW_GS_SHOW_RESOLUTION%x*}"
+        pwgs_res_sw="${pwgs_res_sw1%%-*}"
+        pwgs_res_sh1="${PW_GS_SHOW_RESOLUTION#*x}"
+        pwgs_res_sh="${pwgs_res_sh1%%-*}"
+        PW_GAMESCOPE_ARGS_NEW+=" -W ${pwgs_res_sw} -H ${pwgs_res_sh}"
+
+        if [[ -n "${PW_GS_INTERNAL_RESOLUTION}" && "${PW_GS_INTERNAL_RESOLUTION}" != "0.0" ]] ; then
+            gs_res_w=${PW_GS_SHOW_RESOLUTION:0:4}
+            gs_res_h=${PW_GS_SHOW_RESOLUTION:5:8}
+            pwgs_res_iw=$(echo "${gs_res_w}" "${PW_GS_INTERNAL_RESOLUTION}" | awk '{print $1*$2}')
+            pwgs_res_ih=$(echo "${gs_res_h}" "${PW_GS_INTERNAL_RESOLUTION}" | awk '{print $1*$2}')
+            PW_GAMESCOPE_ARGS_NEW+=" -w ${pwgs_res_iw} -h ${pwgs_res_ih}"
+        fi
+    fi
+
+    [[ -n "${PW_GS_FRAME_LIMIT}" && "${PW_GS_FRAME_LIMIT}" != "disabled" ]] && PW_GAMESCOPE_ARGS_NEW+=" -r ${PW_GS_FRAME_LIMIT}"
+    [[ -n "${PW_GS_MAX_SCALE_FACTOR}" && "${PW_GS_MAX_SCALE_FACTOR}" != "0.0" ]] && PW_GAMESCOPE_ARGS_NEW+=" -m ${PW_GS_MAX_SCALE_FACTOR}"
+    [[ -n "${PW_GS_SCALER_MODE}" && "${PW_GS_SCALER_MODE}" != "disabled" ]] && PW_GAMESCOPE_ARGS_NEW+=" -S ${PW_GS_SCALER_MODE}"
+
+    if [[ -n "${PW_GS_FILTER_MODE}" && "${PW_GS_FILTER_MODE}" != "disabled" ]] ; then
+        if [[ "${PW_GS_FILTER_MODE_OLD}" != "true" ]] ; then
+            PW_GAMESCOPE_ARGS_NEW+=" -F ${PW_GS_FILTER_MODE}"
+        else
+            if [[ "${PW_GS_FILTER_MODE}" == "fsr" ]] ; then
+                PW_GAMESCOPE_ARGS_NEW+=" -U"
+            elif [[ "${PW_GS_FILTER_MODE}" == "nis" ]] ; then
+                PW_GAMESCOPE_ARGS_NEW+=" -Y"
+            fi
+        fi
+        PW_GAMESCOPE_ARGS_NEW+=" --sharpness ${PW_GS_UPSCALE_SHARPNESS}"
+    fi
+
+    [[ -n "${PW_GS_MOUSE_SENSITIVITY}" && "${PW_GS_MOUSE_SENSITIVITY}" != "0.0" ]] && PW_GAMESCOPE_ARGS_NEW+=" -s ${PW_GS_MOUSE_SENSITIVITY}"
+    [[ -n "${PW_GS_SDR_CONTENT_NITS}" && "${PW_GS_SDR_CONTENT_NITS}" != "400" ]] && PW_GAMESCOPE_ARGS_NEW+=" --hdr-sdr-content-nits ${PW_GS_SDR_CONTENT_NITS}"
+    [[ -n "${PW_GS_ITM_SDR_NITS}" && "${PW_GS_ITM_SDR_NITS}" != "0" ]] && PW_GAMESCOPE_ARGS_NEW+=" --hdr-itm-sdr-nits ${PW_GS_ITM_SDR_NITS}"
+    [[ -n "${PW_GS_ITM_TARGET_NITS}" && "${PW_GS_ITM_TARGET_NITS}" != "0" ]] && PW_GAMESCOPE_ARGS_NEW+=" --hdr-itm-target-nits ${PW_GS_ITM_TARGET_NITS}"
+}
+
+# Reset GUI PW_GS_* defaults before parse-backfill from PW_GAMESCOPE_ARGS_NEW.
+pw_gamescope_reset_gui_vars () {
+    local -a gs_gui_bool_vars=(
+    PW_GS_FULLSCREEN PW_GS_FORCE_FULLSCREEN PW_GS_BORDERLESS_WINDOW PW_GS_FORCE_GRAB_CURSOR
+    PW_GS_FORCE_GRAB_KEYBOARD PW_GS_HDR_ENABLE PW_GS_HDR_ITM_ENABLE PW_GS_SDR_GAMMUT_WIDENESS
+    PW_GS_FORCE_COMPOSITION PW_GS_HDR_FORCE_SUPPORT PW_GS_HDR_FORCE_OUTPUT PW_GS_HDR_FORCE_HEATMAP
+    PW_GS_EXPOSE_WAYLAND PW_GS_REALTIME_SCHEDULING PW_GS_MANGOAPP PW_GS_BACKEND_SDL PW_GS_CURSOR_SCALE_HEIGHT
+    )
+    local gs_gui_var
+
+    for gs_gui_var in "${gs_gui_bool_vars[@]}" ; do
+        printf -v "${gs_gui_var}" "%s" "0"
+    done
+
+    PW_GS_SHOW_RESOLUTION="disabled"
+    PW_GS_INTERNAL_RESOLUTION="1.0"
+    PW_GS_FRAME_LIMIT="disabled"
+    PW_GS_MAX_SCALE_FACTOR="0.0"
+    PW_GS_SCALER_MODE="disabled"
+    PW_GS_FILTER_MODE="disabled"
+    PW_GS_UPSCALE_SHARPNESS="10"
+    PW_GS_MOUSE_SENSITIVITY="0.0"
+    PW_GS_SDR_CONTENT_NITS="400"
+    PW_GS_ITM_SDR_NITS="0"
+    PW_GS_ITM_TARGET_NITS="0"
+}
+
+# Keep only allowed gamescope flags/values before writing PW_GAMESCOPE_ARGS_NEW to .ppdb.
+pw_gamescope_sanitize_args () {
+    local gs_disabled_label="${translations[Disabled]}"
+    local gs_disable_label="${translations[Disable]}"
+    local -a gs_args_input gs_args_output
+    local gs_arg gs_next gs_arg_i
+
+    PW_GAMESCOPE_ARGS_NEW="${PW_GAMESCOPE_ARGS_NEW//${gs_disabled_label}/}"
+    PW_GAMESCOPE_ARGS_NEW="${PW_GAMESCOPE_ARGS_NEW//${gs_disable_label}/}"
+    read -r -a gs_args_input <<< "${PW_GAMESCOPE_ARGS_NEW}"
+
+    for ((gs_arg_i=0; gs_arg_i<${#gs_args_input[@]}; gs_arg_i++)) ; do
+        gs_arg="${gs_args_input[$gs_arg_i]}"
+        gs_next="${gs_args_input[$((gs_arg_i + 1))]}"
+        case "${gs_arg}" in
+            -f|-b|-g|--force-windows-fullscreen|--force-grab-cursor|--hdr-enabled|--hdr-itm-enabled|--sdr-gamut-wideness|--force-composition|--hdr-debug-force-support|--hdr-debug-force-output|--hdr-debug-heatmap|--expose-wayland|--rt|--mangoapp|--cursor-scale-height|-U|-Y)
+                gs_args_output+=("${gs_arg}")
+                ;;
+            --backend)
+                if [[ -n "${gs_next}" ]] && [[ ! "${gs_next}" =~ ^- ]] ; then
+                    gs_args_output+=("${gs_arg}" "${gs_next}")
+                    ((gs_arg_i++))
+                fi
+                ;;
+            -W|-H|-w|-h|-r|-m|-S|-F|-s|--sharpness|--hdr-sdr-content-nits|--hdr-itm-sdr-nits|--hdr-itm-target-nits)
+                if [[ -n "${gs_next}" ]] && [[ ! "${gs_next}" =~ ^- ]] ; then
+                    gs_args_output+=("${gs_arg}" "${gs_next}")
+                    ((gs_arg_i++))
+                fi
+                ;;
+        esac
+    done
+
+    PW_GAMESCOPE_ARGS_NEW="${gs_args_output[*]}"
+    [[ -n "${PW_GAMESCOPE_ARGS_NEW}" ]] && PW_GAMESCOPE_ARGS_NEW=" ${PW_GAMESCOPE_ARGS_NEW}"
+}
+
+# Parse gamescope args string back into GUI variables.
+pw_gamescope_parse_args () {
+    local -A gs_flag_to_var=(
+    [-f]="PW_GS_FULLSCREEN"
+    [--force-windows-fullscreen]="PW_GS_FORCE_FULLSCREEN"
+    [-b]="PW_GS_BORDERLESS_WINDOW"
+    [--force-grab-cursor]="PW_GS_FORCE_GRAB_CURSOR"
+    [-g]="PW_GS_FORCE_GRAB_KEYBOARD"
+    [--hdr-enabled]="PW_GS_HDR_ENABLE"
+    [--hdr-itm-enabled]="PW_GS_HDR_ITM_ENABLE"
+    [--sdr-gamut-wideness]="PW_GS_SDR_GAMMUT_WIDENESS"
+    [--force-composition]="PW_GS_FORCE_COMPOSITION"
+    [--hdr-debug-force-support]="PW_GS_HDR_FORCE_SUPPORT"
+    [--hdr-debug-force-output]="PW_GS_HDR_FORCE_OUTPUT"
+    [--hdr-debug-heatmap]="PW_GS_HDR_FORCE_HEATMAP"
+    [--expose-wayland]="PW_GS_EXPOSE_WAYLAND"
+    [--rt]="PW_GS_REALTIME_SCHEDULING"
+    [--mangoapp]="PW_GS_MANGOAPP"
+    [--cursor-scale-height]="PW_GS_CURSOR_SCALE_HEIGHT"
+    )
+    local -A gs_value_to_var=(
+    [-W]="PWGS_OUTPUT_WIDTH"
+    [-H]="PWGS_OUTPUT_HEIGHT"
+    [-r]="PW_GS_FRAME_LIMIT"
+    [-m]="PW_GS_MAX_SCALE_FACTOR"
+    [-S]="PW_GS_SCALER_MODE"
+    [-F]="PW_GS_FILTER_MODE"
+    [--sharpness]="PW_GS_UPSCALE_SHARPNESS"
+    [-s]="PW_GS_MOUSE_SENSITIVITY"
+    [--hdr-sdr-content-nits]="PW_GS_SDR_CONTENT_NITS"
+    [--hdr-itm-sdr-nits]="PW_GS_ITM_SDR_NITS"
+    [--hdr-itm-target-nits]="PW_GS_ITM_TARGET_NITS"
+    [-w]="PWGS_INTERNAL_WIDTH"
+    [-h]="PWGS_INTERNAL_HEIGHT"
+    )
+    local -a PW_GS_ARGS_ARRAY
+    local gs_arg gs_next gs_var gs_arg_i
+
+    pw_gamescope_reset_gui_vars
+    read -r -a PW_GS_ARGS_ARRAY <<< "${PW_GAMESCOPE_ARGS_NEW}"
+    unset PWGS_INTERNAL_WIDTH PWGS_INTERNAL_HEIGHT
+
+    for ((gs_arg_i=0; gs_arg_i<${#PW_GS_ARGS_ARRAY[@]}; gs_arg_i++)) ; do
+        gs_arg="${PW_GS_ARGS_ARRAY[$gs_arg_i]}"
+        gs_var="${gs_flag_to_var[$gs_arg]}"
+
+        if [[ -n "${gs_var}" ]] ; then
+            printf -v "${gs_var}" "%s" "1"
+            continue
+        fi
+
+        case "${gs_arg}" in
+            --backend)
+                gs_next="${PW_GS_ARGS_ARRAY[$((gs_arg_i + 1))]}"
+                if [[ -n "${gs_next}" && "${gs_next}" == "sdl" ]] ; then
+                    PW_GS_BACKEND_SDL="1"
+                fi
+                ;;
+            -U) PW_GS_FILTER_MODE="fsr" ;;
+            -Y) PW_GS_FILTER_MODE="nis" ;;
+            *)
+                gs_var="${gs_value_to_var[$gs_arg]}"
+                if [[ -n "${gs_var}" ]] ; then
+                    gs_next="${PW_GS_ARGS_ARRAY[$((gs_arg_i + 1))]}"
+                    if [[ -n "${gs_next}" ]] && [[ ! "${gs_next}" =~ ^- ]] ; then
+                        printf -v "${gs_var}" "%s" "${gs_next}"
+                        ((gs_arg_i++))
+                    fi
+                fi
+                ;;
+        esac
+    done
+
+    if [[ -n "${PWGS_OUTPUT_WIDTH}" && -n "${PWGS_OUTPUT_HEIGHT}" ]] ; then
+        PW_GS_SHOW_RESOLUTION="${PWGS_OUTPUT_WIDTH}x${PWGS_OUTPUT_HEIGHT}"
+    fi
+    if [[ ! "${PW_GS_SHOW_RESOLUTION}" =~ ^[0-9]+x[0-9]+$ ]] ; then
+        PW_GS_SHOW_RESOLUTION="disabled"
+    fi
+
+    if [[ "${PW_GS_SHOW_RESOLUTION}" != "disabled" ]] \
+    && [[ -n "${PWGS_INTERNAL_WIDTH}" && -n "${PWGS_INTERNAL_HEIGHT}" ]]
+    then
+        GS_RES_W="${PW_GS_SHOW_RESOLUTION%x*}"
+        GS_RES_H="${PW_GS_SHOW_RESOLUTION#*x}"
+        if [[ -n "${GS_RES_W}" && -n "${GS_RES_H}" ]] \
+        && [[ "${GS_RES_W}" != "0" && "${GS_RES_H}" != "0" ]]
+        then
+            if [[ "${PWGS_INTERNAL_WIDTH}" == "${GS_RES_W}" && "${PWGS_INTERNAL_HEIGHT}" == "${GS_RES_H}" ]] ; then
+                PW_GS_INTERNAL_RESOLUTION="1.0"
+            else
+                PW_GS_INTERNAL_RESOLUTION="$(awk -v iw="${PWGS_INTERNAL_WIDTH}" -v ow="${GS_RES_W}" 'BEGIN { printf "%.1f", iw / ow }')"
+            fi
+        fi
+    fi
+}
+
 # GUI GAMESCOPE
 gui_gamescope () {
     KEY_GS_GUI=$RANDOM
+    local -a gs_ppdb_vars=(PW_GAMESCOPE PW_GAMESCOPE_ARGS_NEW PW_GS_ENABLE_GAMESCOPE_WSI PW_GS_SDL_VIDEODRIVER_X11)
     PW_GS_LIST=(PW_GS_FULLSCREEN PW_GS_FORCE_FULLSCREEN PW_GS_BORDERLESS_WINDOW PW_GS_FORCE_GRAB_CURSOR
     PW_GS_FORCE_GRAB_KEYBOARD PW_GS_HDR_ENABLE PW_GS_ENABLE_GAMESCOPE_WSI PW_GS_HDR_ITM_ENABLE PW_GS_SDR_GAMMUT_WIDENESS
     PW_GS_FORCE_COMPOSITION PW_GS_HDR_FORCE_SUPPORT PW_GS_HDR_FORCE_OUTPUT PW_GS_HDR_FORCE_HEATMAP
@@ -6360,6 +6545,11 @@ gui_gamescope () {
         else
             GS_FILTER_CB="linear!nearest!fsr!nis!pixel"
         fi
+    fi
+
+    # Backfill PW_GS_* from PW_GAMESCOPE_ARGS_NEW so yad widgets reflect saved args.
+    if [[ -n "${PW_GAMESCOPE_ARGS_NEW// }" ]] ; then
+        pw_gamescope_parse_args
     fi
 
     PW_GS_FULLSCREEN_INFO=${translations[Make the window fullscreen]}
@@ -6474,6 +6664,7 @@ gui_gamescope () {
             ;;
     esac
 
+    # Read yad values into PW_GS_* and then rebuild PW_GAMESCOPE_ARGS_NEW from that state.
     read -r -a output_yad_gs <"${PW_TMPFS_PATH}/tmp_yad_gs_set"
     bool_from_yad="0"
     for boole_to_int in "${PW_GS_LIST[@]}" ; do
@@ -6487,6 +6678,9 @@ gui_gamescope () {
 
     IFS='%' read -r -a PW_ADD_SETTINGS_GS <"${PW_TMPFS_PATH}/tmp_yad_gs_set_cb"
     PW_GS_SHOW_RESOLUTION="${PW_ADD_SETTINGS_GS[0]}"
+    if [[ ! "${PW_GS_SHOW_RESOLUTION}" =~ ^[0-9]+x[0-9]+$ ]] ; then
+        PW_GS_SHOW_RESOLUTION="disabled"
+    fi
     PW_GS_INTERNAL_RESOLUTION="${PW_ADD_SETTINGS_GS[1]//','/'.'}"
     PW_GS_FRAME_LIMIT="${PW_ADD_SETTINGS_GS[2]}"
     PW_GS_SCALER_MODE="${PW_ADD_SETTINGS_GS[3]}"
@@ -6498,10 +6692,15 @@ gui_gamescope () {
     PW_GS_ITM_SDR_NITS="${PW_ADD_SETTINGS_GS[9]}"
     PW_GS_ITM_TARGET_NITS="${PW_ADD_SETTINGS_GS[10]}"
 
-    edit_db_from_gui "${PW_GS_LIST[@]}" PW_GAMESCOPE PW_GS_SHOW_RESOLUTION PW_GS_INTERNAL_RESOLUTION \
-    PW_GS_FRAME_LIMIT PW_GS_SCALER_MODE PW_GS_FILTER_MODE \
-    PW_GS_UPSCALE_SHARPNESS PW_GS_MAX_SCALE_FACTOR PW_GS_MOUSE_SENSITIVITY \
-    PW_GS_SDR_CONTENT_NITS PW_GS_ITM_SDR_NITS PW_GS_ITM_TARGET_NITS
+    # Rebuild args from current PW_GS_* values produced by yad widgets.
+    pw_gamescope_build_args
+
+    pw_gamescope_sanitize_args
+
+    # Keep ppdb export list consistent before re-writing gamescope keys.
+    sed -i '/^export PW_GS_/d' "${portwine_exe}.ppdb"
+    sed -i '/^export PW_GAMESCOPE_ARGS_NEW=/d' "${portwine_exe}.ppdb"
+    edit_db_from_gui "${gs_ppdb_vars[@]}"
 
     restart_pp
 }


### PR DESCRIPTION
Я решил добавить в PPQt gamescope, и понял что миллион переменных на каждый чих это совершенно не удобно и вписал всё в один PW_GAMESCOPE_ARGS_NEW