### PR TITLE
fix(cli): normalize file:// argument from pcmanfm

### DIFF
--- a/data_from_portwine/scripts/start.sh
+++ b/data_from_portwine/scripts/start.sh
@@ -74,6 +74,12 @@ if [[ ${1,,} == "cli" ]] ; then
 fi
 check_variables PW_CLI "0"
 
+if [[ "${1:-}" == file://* ]] ; then
+    pw_file_path="${1#file://}"
+    pw_file_path="${pw_file_path//%20/ }"
+    set -- "${pw_file_path}" "${@:2}"
+fi
+
 if [[ "${1,,}" =~ \.ppack$ ]] ; then
     export PW_NO_RESTART_PPDB="1"
     export PW_DISABLED_CREATE_DB="1"


### PR DESCRIPTION
PCManFM передаёт путь как uri file:// с %20 вместо пробелов в итоге открыть игры через PP в PCManFM было невозможно