### PR TITLE
steamplay: apply PortWINE launch settings in Proton path

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -2069,24 +2069,7 @@ stop_portwine () {
         xrandr --output "$PW_SCREEN_PRIMARY" --mode "$PW_SCREEN_RESOLUTION"
     fi
 
-    if [[ "${PW_DISABLE_COMPOSITING}" == "1" ]] \
-    && ! check_gamescope_session
-    then
-        if [[ "${DESKTOP_SESSION}" =~ "plasma" ]] ; then
-            kde_version=$(plasmashell --version 2>/dev/null | grep -oE '[0-9]+' | head -1)
-            if [[ -n "$kde_version" && "$kde_version" -lt 6 ]]; then
-                qdbus org.kde.KWin /Compositor resume
-            fi
-        elif [[ "${DESKTOP_SESSION}" =~ "mate" ]] ; then
-            gsettings set org.mate.Marco.general compositing-manager true
-        elif [[ "${DESKTOP_SESSION}" =~ "xfce" ]] ; then
-            xfconf-query -c xfwm4 -p /general/use_compositing -s true
-        elif [[ "${DESKTOP_SESSION}" =~ "cinnamon" ]] ; then
-            gsettings set org.cinnamon.muffin unredirect-fullscreen-windows false
-        elif [[ "${DESKTOP_SESSION}" =~ "deepin" ]] ; then
-            dbus-send --session --dest=com.deepin.WMSwitcher --type=method_call /com/deepin/WMSwitcher com.deepin.WMSwitcher.RequestSwitchWM
-        fi
-    fi
+    pw_toggle_compositing restore
     pw_stop_progress_bar
     try_remove_file "${PORT_SCRIPTS_PATH}/0"
     try_remove_file "${PORT_SCRIPTS_PATH}/1"
@@ -3501,6 +3484,230 @@ pw_enable_gamemode_basic () {
     return 0
 }
 
+pw_apply_ray_tracing_and_nvapi_settings () {
+    if [[ "${PW_USE_RAY_TRACING}" == "1" ]] ; then
+        var_vkd3d_config_update dxr
+        if [[ $(check_vendor_gpu) == "amd" ]] ; then
+            var_radv_perftest_config_update rt
+        fi
+    else
+        var_vkd3d_config_update nodxr
+    fi
+
+    if [[ "${PW_USE_NVAPI_AND_DLSS}" == "1" ]] ; then
+        export DXVK_ENABLE_NVAPI="1"
+    else
+        export DXVK_ENABLE_NVAPI="0"
+    fi
+}
+
+pw_apply_shader_cache_settings () {
+    if [[ "${PW_USE_SHADER_CACHE}" == "1" ]] ; then
+        create_new_dir "${PW_VULKAN_DIR}/gl_shader_cache"
+        create_new_dir "${PW_VULKAN_DIR}/mesa_shader"
+        check_variables __GL_SHADER_DISK_CACHE "1"
+        check_variables __GL_SHADER_DISK_CACHE_PATH "${PW_VULKAN_DIR}/gl_shader_cache"
+        check_variables __GL_SHADER_DISK_CACHE_SIZE "50000000000"
+        check_variables __GL_SHADER_DISK_CACHE_SKIP_CLEANUP "1"
+        check_variables MESA_SHADER_CACHE_DIR "${PW_VULKAN_DIR}/mesa_shader"
+    else
+        export __GL_SHADER_DISK_CACHE="0"
+        export DXVK_STATE_CACHE="0"
+        export VKD3D_SHADER_CACHE_PATH="0"
+    fi
+}
+
+pw_apply_steamplay_shader_cache_settings () {
+    if [[ "${PW_USE_SHADER_CACHE}" == "1" ]] ; then
+        # Let Proton/Steam use its own Fossilize cache flow first.
+        export DXVK_STATE_CACHE="1"
+        unset DISABLE_VK_LAYER_fossilize
+        unset DXVK_STATE_CACHE_PATH
+        unset VKD3D_SHADER_CACHE_PATH
+        unset MESA_SHADER_CACHE_DIR
+        unset __GL_SHADER_DISK_CACHE_PATH
+        unset __GL_SHADER_DISK_CACHE_SIZE
+        unset __GL_SHADER_DISK_CACHE_SKIP_CLEANUP
+    else
+        export __GL_SHADER_DISK_CACHE="0"
+        export DXVK_STATE_CACHE="0"
+        export VKD3D_SHADER_CACHE_PATH="0"
+        export DISABLE_VK_LAYER_fossilize="1"
+    fi
+}
+
+pw_apply_graphics_env_tweaks () {
+    if [[ "${PW_FIX_VIDEO_IN_GAME}" == 1 ]]
+    then export WINE_DO_NOT_CREATE_DXGI_DEVICE_MANAGER="1"
+    else export WINE_DO_NOT_CREATE_DXGI_DEVICE_MANAGER="0"
+    fi
+
+    if [[ "${PW_REDUCE_PULSE_LATENCY}" == 1 ]] ; then
+        export PULSE_LATENCY_MSEC=60
+    else
+        unset PULSE_LATENCY_MSEC
+    fi
+
+    if [[ "${PW_WINE_FULLSCREEN_FSR}" == "1" ]] \
+    && ! check_gamescope_session
+    then
+        export WINE_FULLSCREEN_FSR="1"
+        export WINE_FULLSCREEN_FSR_STRENGTH="2"
+        export WINE_FULLSCREEN_INTEGER_SCALING="0"
+    else
+        export WINE_FULLSCREEN_FSR="0"
+        unset WINE_FULLSCREEN_FAKE_CURRENT_RES WINE_FULLSCREEN_FSR_STRENGTH WINE_FULLSCREEN_INTEGER_SCALING
+    fi
+
+    if [[ "${PW_WINE_CPU_TOPOLOGY}" != "disabled" ]] ; then
+        export WINE_CPU_TOPOLOGY="${PW_WINE_CPU_TOPOLOGY}"
+    fi
+
+    if [[ "${PW_MESA_GL_VERSION_OVERRIDE}" != "disabled" ]] ; then
+        export MESA_GL_VERSION_OVERRIDE="${PW_MESA_GL_VERSION_OVERRIDE}"
+        if [[ $PW_MESA_GL_VERSION_OVERRIDE = 3.2COMPAT ]] ; then
+            export MESA_GLSL_VERSION_OVERRIDE="150"
+        else
+            MESA_GLSL_VERSION_OVERRIDE="${PW_MESA_GL_VERSION_OVERRIDE//./}"
+            export MESA_GLSL_VERSION_OVERRIDE="${MESA_GLSL_VERSION_OVERRIDE//COMPAT/}0"
+        fi
+    fi
+
+    if [[ "${PW_VKD3D_FEATURE_LEVEL}" != "disabled" ]] ; then
+        export VKD3D_FEATURE_LEVEL="${PW_VKD3D_FEATURE_LEVEL}"
+    fi
+
+    if [[ "${PW_MESA_VK_WSI_PRESENT_MODE}" != "disabled" ]] ; then
+        export MESA_VK_WSI_PRESENT_MODE="${PW_MESA_VK_WSI_PRESENT_MODE}"
+        case "$PW_MESA_VK_WSI_PRESENT_MODE" in
+            immediate|mailbox)
+                check_variables vblank_mode "0"
+                check_variables __GL_SYNC_TO_VBLANK "0"
+                ;;
+            relaxed|fifo)
+                check_variables vblank_mode "1"
+                check_variables __GL_SYNC_TO_VBLANK "1"
+                ;;
+        esac
+    elif [[ "${PW_USE_LS_FRAME_GEN}" == "1" ]] ; then
+        export MESA_VK_WSI_PRESENT_MODE="immediate"
+        unset vblank_mode __GL_SYNC_TO_VBLANK
+    fi
+}
+
+pw_apply_us_layout_settings () {
+    if [[ "$PW_USE_US_LAYOUT" == "1" ]] \
+    && ! check_wayland_session \
+    && command -v setxkbmap &>/dev/null
+    then
+        setxkbmap -model pc101 us -print | xkbcomp - "$DISPLAY" &>/dev/null
+    else
+        export PW_USE_US_LAYOUT="0"
+    fi
+}
+
+pw_apply_wined3d_settings () {
+    [[ "$PW_USE_GALLIUM_ZINK" == "1" || "$PW_USE_WINED3D_VULKAN" == "1" ]] \
+    && export PROTON_USE_WINED3D="1" || unset PROTON_USE_WINED3D
+
+    if [[ "$PW_USE_GALLIUM_ZINK" == "1" ]] ; then
+        print_info "Use GALLIUM-ZINK (OpenGL on MESA vulkan drivers)"
+        export __GLX_VENDOR_LIBRARY_NAME="mesa"
+        export MESA_LOADER_DRIVER_OVERRIDE="zink"
+        export GALLIUM_DRIVER="zink"
+        if ! check_wayland_session && ! check_gamescope_session && [[ "${PW_GAMESCOPE}" != "1" ]] ; then
+            export LIBGL_KOPPER_DRI2="1"
+        fi
+        [[ $(check_vendor_gpu) == "nouveau" ]] && export NOUVEAU_USE_ZINK="1"
+        export WINE_D3D_CONFIG="renderer=gl"
+        return
+    fi
+
+    if [[ "$PW_USE_WINED3D_VULKAN" == "1" ]] ; then
+        print_info "Use DAMAVAND (DirectX to wined3d vulkan)"
+        export WINE_D3D_CONFIG="renderer=vulkan"
+        return
+    fi
+
+    unset WINE_D3D_CONFIG MESA_LOADER_DRIVER_OVERRIDE GALLIUM_DRIVER LIBGL_KOPPER_DRI2 NOUVEAU_USE_ZINK
+}
+
+pw_apply_wayland_settings () {
+    if check_wayland_session \
+    && [[ $PW_USE_NATIVE_WAYLAND == "1" || $PW_USE_DXVK_HDR == "1" ]]
+    then
+        [[ $PW_USE_DXVK_HDR == "1" ]] && export DXVK_HDR="1"
+        export WINE_WAYLAND_HACKS="1"
+        export PROTON_NO_STEAMINPUT="1"
+        export WAYLANDDRV_NO_IME="1"
+        export PROTON_USE_XALIA="0"
+
+        if [[ -d "$WINEDIR/share/X11/locale" ]] ; then
+            check_variables "XLOCALEDIR" "$WINEDIR/share/X11/locale"
+        fi
+
+        var_winedlloverride_update "winex11.drv=d;winewayland.drv=b"
+
+        print_warning "Wayland in use. Force dpi=96"
+        export PW_WINE_DPI_VALUE="96"
+
+        if [[ -f "$WINEDIR/lib/libxkbregistry.so" ]] \
+        || [[ -f "$WINEDIR/lib/x86_64-linux-gnu/libxkbregistry.so" ]]
+        then print_info "runtime in use with native wayland."
+        else
+            print_warning "Wine is not support native wayland with runtime! Force disabled SLR."
+            export PW_USE_RUNTIME="0"
+        fi
+    else
+        export GST_GL_WINDOW="x11"
+        unset WINE_WAYLAND_HACKS DXVK_HDR
+        check_variables PROTON_USE_XALIA 0
+    fi
+}
+
+pw_toggle_compositing () {
+    if [[ "${PW_DISABLE_COMPOSITING}" != "1" ]] \
+    || check_gamescope_session
+    then
+        return 0
+    fi
+
+    case "$1" in
+        disable)
+            if [[ "${DESKTOP_SESSION}" =~ "plasma" ]] ; then
+                kde_version=$(plasmashell --version 2>/dev/null | grep -oE '[0-9]+' | head -1)
+                if [[ -n "$kde_version" && "$kde_version" -lt 6 ]]; then
+                    qdbus org.kde.KWin /Compositor suspend
+                fi
+            elif [[ "${DESKTOP_SESSION}" =~ "mate" ]] ; then
+                gsettings set org.mate.Marco.general compositing-manager false
+            elif [[ "${DESKTOP_SESSION}" =~ "xfce" ]] ; then
+                xfconf-query -c xfwm4 -p /general/use_compositing -s false
+            elif [[ "${DESKTOP_SESSION}" =~ "cinnamon" ]] ; then
+                gsettings set org.cinnamon.muffin unredirect-fullscreen-windows true
+            elif [[ "${DESKTOP_SESSION}" =~ "deepin" ]] ; then
+                dbus-send --session --dest=com.deepin.WMSwitcher --type=method_call /com/deepin/WMSwitcher com.deepin.WMSwitcher.RequestSwitchWM
+            fi
+            ;;
+        restore)
+            if [[ "${DESKTOP_SESSION}" =~ "plasma" ]] ; then
+                kde_version=$(plasmashell --version 2>/dev/null | grep -oE '[0-9]+' | head -1)
+                if [[ -n "$kde_version" && "$kde_version" -lt 6 ]]; then
+                    qdbus org.kde.KWin /Compositor resume
+                fi
+            elif [[ "${DESKTOP_SESSION}" =~ "mate" ]] ; then
+                gsettings set org.mate.Marco.general compositing-manager true
+            elif [[ "${DESKTOP_SESSION}" =~ "xfce" ]] ; then
+                xfconf-query -c xfwm4 -p /general/use_compositing -s true
+            elif [[ "${DESKTOP_SESSION}" =~ "cinnamon" ]] ; then
+                gsettings set org.cinnamon.muffin unredirect-fullscreen-windows false
+            elif [[ "${DESKTOP_SESSION}" =~ "deepin" ]] ; then
+                dbus-send --session --dest=com.deepin.WMSwitcher --type=method_call /com/deepin/WMSwitcher com.deepin.WMSwitcher.RequestSwitchWM
+            fi
+            ;;
+    esac
+}
+
 start_portwine () {
     pw_skip_get_info
     if [[ "${PW_LOCALE_SELECT}" != "disabled" ]] && [[ -n "${PW_LOCALE_SELECT}" ]] ; then
@@ -3570,7 +3777,7 @@ start_portwine () {
         if ! check_flatpak ; then
             if [[ -d "${WINEDIR}/lib64/gstreamer-1.0" ]]
             then export GST_PLUGIN_SYSTEM_PATH_1_0="${WINEDIR}/lib64/gstreamer-1.0:${WINEDIR}/lib/gstreamer-1.0"
-            elif  [[ -d "${WINEDIR}/lib/x86_64-linux-gnu/gstreamer-1.0" ]]
+            elif [[ -d "${WINEDIR}/lib/x86_64-linux-gnu/gstreamer-1.0" ]]
             then export GST_PLUGIN_SYSTEM_PATH_1_0="${WINEDIR}/lib/x86_64-linux-gnu/gstreamer-1.0:${WINEDIR}/lib/i386-linux-gnu/gstreamer-1.0"
             fi
         fi
@@ -3809,28 +4016,17 @@ start_portwine () {
 
     pw_optiscaler_sync_files
 
-    if [[ "${PW_USE_RAY_TRACING}" == "1" ]] ; then
-        var_vkd3d_config_update dxr
-        if [[ $(check_vendor_gpu) == "amd" ]] ; then
-            var_radv_perftest_config_update rt
+    pw_apply_ray_tracing_and_nvapi_settings
+    if [[ "${PW_USE_NVAPI_AND_DLSS}" == "1" ]] \
+    && echo "$LSPCI_VGA" | grep -i -q 'nvidia'
+    then
+        FIND_NVNGX="$(dirname "$(find /usr/* -type f -name "nvngx.dll" 2>/dev/null | head -n 1 | awk '{print $1}')")"
+        if [[ -n "$FIND_NVNGX" ]] ; then
+            try_copy_file_with_checksums "${FIND_NVNGX}/nvngx.dll" "${WINEPREFIX}/drive_c/windows/system32/nvngx.dll"
+            try_copy_file_with_checksums "${FIND_NVNGX}/_nvngx.dll" "${WINEPREFIX}/drive_c/windows/system32/_nvngx.dll"
+            var_winedlloverride_update "nvngx,_nvngx=n"
+            export NVIDIA_WINE_DLL_DIR="${FIND_NVNGX}"
         fi
-    else
-        var_vkd3d_config_update nodxr
-    fi
-
-    if [[ "${PW_USE_NVAPI_AND_DLSS}" == "1" ]] ; then
-        export DXVK_ENABLE_NVAPI="1"
-        if echo "$LSPCI_VGA" | grep -i -q 'nvidia' ; then
-            FIND_NVNGX="$(dirname $(find /usr/* -type f -name "nvngx.dll" 2>/dev/null | head -n 1 | awk '{print $1}'))"
-            if [[ -n "$FIND_NVNGX" ]] ; then
-                try_copy_file_with_checksums "${FIND_NVNGX}/nvngx.dll" "${WINEPREFIX}/drive_c/windows/system32/nvngx.dll"
-                try_copy_file_with_checksums "${FIND_NVNGX}/_nvngx.dll" "${WINEPREFIX}/drive_c/windows/system32/_nvngx.dll"
-                var_winedlloverride_update "nvngx,_nvngx=n"
-                export NVIDIA_WINE_DLL_DIR="${FIND_NVNGX}"
-            fi
-        fi
-    else
-        export DXVK_ENABLE_NVAPI="0"
     fi
 
     [[ "${PW_USE_LS_FRAME_GEN}" == "1" ]] && set_to_dxvk_conf low_latency
@@ -3840,14 +4036,11 @@ start_portwine () {
     else export WINE_HEAP_DELAY_FREE="0"
     fi
 
+    pw_apply_graphics_env_tweaks
+
     if [[ "${PW_WINE_ALLOW_XIM}" == 1 ]]
     then export WINE_ALLOW_XIM="1"
     else export WINE_ALLOW_XIM="0"
-    fi
-
-    if [[ "${PW_FIX_VIDEO_IN_GAME}" == 1 ]]
-    then export WINE_DO_NOT_CREATE_DXGI_DEVICE_MANAGER="1"
-    else export WINE_DO_NOT_CREATE_DXGI_DEVICE_MANAGER="0"
     fi
 
     if [[ -f "$PATH_TO_GAME/MangoHud.conf" ]] ; then
@@ -3987,21 +4180,7 @@ fi
         unset PROTON_BATTLEYE_RUNTIME PROTON_EAC_RUNTIME
     fi
 
-    if [[ "${PW_REDUCE_PULSE_LATENCY}" == 1 ]] ; then
-        export PULSE_LATENCY_MSEC=60
-        # export PIPEWIRE_LATENCY=128/48000
-    else
-        unset PULSE_LATENCY_MSEC
-    fi
-
-    if [[ "$PW_USE_US_LAYOUT" == "1" ]] \
-    && ! check_wayland_session \
-    && command -v setxkbmap &>/dev/null
-    then
-        setxkbmap -model pc101 us -print | xkbcomp - $DISPLAY &>/dev/null
-    else
-        export PW_USE_US_LAYOUT="0"
-    fi
+    pw_apply_us_layout_settings
 
     D3D_EXTRAS_LIBS="d3dcompiler_33 d3dcompiler_34 d3dcompiler_35 d3dcompiler_36 d3dcompiler_37
     d3dcompiler_38 d3dcompiler_39 d3dcompiler_40 d3dcompiler_41 d3dcompiler_42 d3dcompiler_43 d3dcompiler_46
@@ -4100,34 +4279,15 @@ fi
     if [[ $PW_USE_GALLIUM_NINE == "1" ]] ; then
         print_info "Use GALLIUM-NINE (Native DX9 on MESA drivers)"
         unset PW_VKBASALT PW_MANGOHUD PW_WINE_FULLSCREEN_FSR DXVK_ENABLE_NVAPI PW_USE_VRCLIENT
+        export WINE_FULLSCREEN_FSR="0"
+        unset WINE_FULLSCREEN_FAKE_CURRENT_RES WINE_FULLSCREEN_FSR_STRENGTH WINE_FULLSCREEN_INTEGER_SCALING
         rm_from_var CP_WINE_FILES "d3d9"
         CP_GALLIUM_NINE_FILES="d3d9"
     fi
 
-    # GALLIUM ZINK
-    if [[ $PW_USE_GALLIUM_ZINK == "1" ]] ; then
-        print_info "Use GALLIUM-ZINK (OpenGL on MESA vulkan drivers)"
-        export  __GLX_VENDOR_LIBRARY_NAME="mesa"
-        export MESA_LOADER_DRIVER_OVERRIDE="zink"
-        export GALLIUM_DRIVER="zink"
-        if ! check_wayland_session \
-        && ! check_gamescope_session \
-        && [[ "${PW_GAMESCOPE}" != "1" ]]
-        then
-            export LIBGL_KOPPER_DRI2="1"
-        fi
-        [[ $(check_vendor_gpu) == "nouveau" ]] && export NOUVEAU_USE_ZINK="1"
-    fi
-
-    # WINED3D VULKAN
-    if [[ $PW_USE_WINED3D_VULKAN == "1" ]] ; then
-        print_info "Use DAMAVAND (DirectX to wined3d vulkan)"
-        export WINE_D3D_CONFIG="renderer=vulkan"
-    else
-        if [[ $PW_VULKAN_USE == "0" ]] \
-        || [[ $PW_USE_GALLIUM_NINE == "1" ]] || [[ $PW_USE_GALLIUM_ZINK == "1" ]] ; then
-            export WINE_D3D_CONFIG="renderer=gl"
-        fi
+    pw_apply_wined3d_settings
+    if [[ $PW_VULKAN_USE == "0" ]] || [[ $PW_USE_GALLIUM_NINE == "1" ]] ; then
+        export WINE_D3D_CONFIG="renderer=gl"
     fi
 
     export __GL_YIELD="NOTHING"
@@ -4502,77 +4662,13 @@ fi
     if [[ "$PW_USE_VRCLIENT" = "1" ]] ; then
         if [[ ! -d "${WINEPREFIX}/drive_c/vrclient/bin" ]] ; then
             create_new_dir "${WINEPREFIX}/drive_c/vrclient/bin"
-            try_force_link_file "${WINEDIR}"/lib/wine/i386-windows/vrclient.dll "${WINEPREFIX}/drive_c/vrclient/bin/vrclient.dll"
-            try_force_link_file "${WINEDIR}"/lib64/wine/x86_64-windows/vrclient_x64.dll "${WINEPREFIX}/drive_c/vrclient/bin/vrclient_x64.dll"
+            try_force_link_file "${WINEDIR}/lib/wine/i386-windows/vrclient.dll" "${WINEPREFIX}/drive_c/vrclient/bin/vrclient.dll"
+            try_force_link_file "${WINEDIR}/lib64/wine/x86_64-windows/vrclient_x64.dll" "${WINEPREFIX}/drive_c/vrclient/bin/vrclient_x64.dll"
         fi
     else
         var_winedlloverride_update "wineopenxr,vrclient,vrclient_x64,openvr_api_dxvk="
     fi
-
-    if [[ "${PW_USE_SHADER_CACHE}" == "1" ]] ; then
-        create_new_dir "${PW_VULKAN_DIR}/gl_shader_cache"
-        create_new_dir "${PW_VULKAN_DIR}/mesa_shader"
-        check_variables __GL_SHADER_DISK_CACHE "1"
-        check_variables __GL_SHADER_DISK_CACHE_PATH "${PW_VULKAN_DIR}/gl_shader_cache"
-        check_variables __GL_SHADER_DISK_CACHE_SIZE "50000000000"
-        check_variables __GL_SHADER_DISK_CACHE_SKIP_CLEANUP "1"
-        check_variables MESA_SHADER_CACHE_DIR "${PW_VULKAN_DIR}/mesa_shader"
-    else
-        export __GL_SHADER_DISK_CACHE="0"
-        export DXVK_STATE_CACHE="disable"
-        export VKD3D_SHADER_CACHE_PATH="0"
-    fi
-
-    if [[ "${PW_WINE_FULLSCREEN_FSR}" == "1" ]] \
-    && ! check_gamescope_session
-    then
-        export WINE_FULLSCREEN_FSR="1"
-        export WINE_FULLSCREEN_FSR_STRENGTH="2"
-        export WINE_FULLSCREEN_INTEGER_SCALING="0"
-    else
-        export WINE_FULLSCREEN_FSR="0"
-        unset WINE_FULLSCREEN_FAKE_CURRENT_RES WINE_FULLSCREEN_FSR_STRENGTH WINE_FULLSCREEN_INTEGER_SCALING
-    fi
-
-    if [[ "${PW_WINE_CPU_TOPOLOGY}" != "disabled" ]] ; then
-        export WINE_CPU_TOPOLOGY="${PW_WINE_CPU_TOPOLOGY}"
-    fi
-
-    if [[ -n "${PW_VK_ICD_FILENAMES}" ]] ; then
-        export VK_ICD_FILENAMES="${PW_VK_ICD_FILENAMES}"
-        export VK_DRIVER_FILES="${PW_VK_ICD_FILENAMES}"
-    fi
-
-    if [[ "${PW_MESA_GL_VERSION_OVERRIDE}" != "disabled" ]] ; then
-        export MESA_GL_VERSION_OVERRIDE="${PW_MESA_GL_VERSION_OVERRIDE}"
-        if [[ $PW_MESA_GL_VERSION_OVERRIDE = 3.2COMPAT ]] ; then
-            export MESA_GLSL_VERSION_OVERRIDE="150"
-        else
-            MESA_GLSL_VERSION_OVERRIDE="${PW_MESA_GL_VERSION_OVERRIDE//./}"
-            export MESA_GLSL_VERSION_OVERRIDE="${MESA_GLSL_VERSION_OVERRIDE//COMPAT/}0"
-        fi
-    fi
-
-    if [[ "${PW_VKD3D_FEATURE_LEVEL}" != "disabled" ]] ; then
-        export VKD3D_FEATURE_LEVEL="${PW_VKD3D_FEATURE_LEVEL}"
-    fi
-
-    if [[ "${PW_MESA_VK_WSI_PRESENT_MODE}" != "disabled" ]] ; then
-        export MESA_VK_WSI_PRESENT_MODE="${PW_MESA_VK_WSI_PRESENT_MODE}"
-        case "$PW_MESA_VK_WSI_PRESENT_MODE" in
-            immediate|mailbox)
-                check_variables vblank_mode "0"
-                check_variables __GL_SYNC_TO_VBLANK "0"
-                ;;
-            relaxed|fifo)
-                check_variables vblank_mode "1"
-                check_variables __GL_SYNC_TO_VBLANK "1"
-                ;;
-        esac
-    elif [[ "${PW_USE_LS_FRAME_GEN}" == "1" ]] ; then
-        export MESA_VK_WSI_PRESENT_MODE="immediate"
-        unset vblank_mode __GL_SYNC_TO_VBLANK
-    fi
+    pw_apply_shader_cache_settings
 
     #run_winetricks_from_db
     if [[ -n "${PW_MUST_HAVE_DLL}" ]] ; then
@@ -4644,36 +4740,10 @@ fi
         get_and_set_reg_file --add 'System\CurrentControlSet\Services\winebus' 'Enable SDL' 'REG_DWORD' "1" "system"
     fi
 
-    if check_wayland_session \
-    && [[ $PW_USE_NATIVE_WAYLAND == "1" || $PW_USE_DXVK_HDR == "1" ]]
-    then
-        [[ $PW_USE_DXVK_HDR == "1" ]] && export DXVK_HDR="1"
-        export WINE_WAYLAND_HACKS="1"
-        export PROTON_NO_STEAMINPUT="1"
-        export WAYLANDDRV_NO_IME="1"
-        export PROTON_USE_XALIA="0"
-
-        if [[ -d "$WINEDIR/share/X11/locale" ]] ; then
-            check_variables "XLOCALEDIR" "$WINEDIR/share/X11/locale"
-        fi
-
-        var_winedlloverride_update "winex11.drv=d;winewayland.drv=b"
+    pw_apply_wayland_settings
+    if [[ -n "${WINE_WAYLAND_HACKS:-}" ]] ; then
         get_and_set_reg_file --add 'Software\Wine\Drivers' 'Graphics' 'REG_SZ' "x11,wayland" "user"
-
-        print_warning "Wayland in use. Force dpi=96"
-        export PW_WINE_DPI_VALUE="96"
-
-        if [[ -f "$WINEDIR/lib/libxkbregistry.so" ]] \
-        || [[ -f "$WINEDIR/lib/x86_64-linux-gnu/libxkbregistry.so" ]]
-        then print_info "runtime in use with native wayland."
-        else
-            print_warning "Wine is not support native wayland with runtime! Force disabled SLR."
-            export PW_USE_RUNTIME="0"
-        fi
     else
-        export GST_GL_WINDOW="x11"
-        unset WINE_WAYLAND_HACKS DXVK_HDR
-        check_variables PROTON_USE_XALIA 0
         get_and_set_reg_file --delete 'Software\Wine\Drivers' 'Graphics'
     fi
 
@@ -4711,24 +4781,7 @@ fi
         done
     fi
     
-    if [[ "${PW_DISABLE_COMPOSITING}" == "1" ]] \
-    && ! check_gamescope_session
-    then
-        if [[ "${DESKTOP_SESSION}" =~ "plasma" ]] ; then
-            kde_version=$(plasmashell --version 2>/dev/null | grep -oE '[0-9]+' | head -1)
-            if [[ -n "$kde_version" && "$kde_version" -lt 6 ]]; then
-                qdbus org.kde.KWin /Compositor suspend
-            fi
-        elif [[ "${DESKTOP_SESSION}" =~ "mate" ]] ; then
-            gsettings set org.mate.Marco.general compositing-manager false
-        elif [[ "${DESKTOP_SESSION}" =~ "xfce" ]] ; then
-            xfconf-query -c xfwm4 -p /general/use_compositing -s false
-        elif [[ "${DESKTOP_SESSION}" =~ "cinnamon" ]] ; then
-            gsettings set org.cinnamon.muffin unredirect-fullscreen-windows true
-        elif [[ "${DESKTOP_SESSION}" =~ "deepin" ]] ; then
-            dbus-send --session --dest=com.deepin.WMSwitcher --type=method_call /com/deepin/WMSwitcher com.deepin.WMSwitcher.RequestSwitchWM
-        fi
-    fi
+    pw_toggle_compositing disable
 
     pw_prepare_gamescope_launch
 
@@ -4896,11 +4949,18 @@ pw_yad_form_vulkan () {
 
 steamplay_launch () {
     if [[ -n "${portwine_exe:-}" ]]; then
+        local -a steamplay_launch_options=()
         local steamplay_ld_library_path
+        local proton_runner
         cd "$(dirname "${portwine_exe}")"
         export PATH_TO_GAME="$(pwd)"
         export PORTWINE_DB_FILE="${portwine_exe}.ppdb"
         [[ -f "${PORTWINE_DB_FILE}" ]] && source "${PORTWINE_DB_FILE}"
+
+        if [[ "${PW_LOCALE_SELECT}" != "disabled" ]] && [[ -n "${PW_LOCALE_SELECT}" ]]; then
+            export LC_ALL="${PW_LOCALE_SELECT}"
+            export HOST_LC_ALL="${LC_ALL}"
+        fi
 
         steamplay_ld_library_path="${LD_LIBRARY_PATH}:${STEAM_RUNTIME_LIBRARY_PATH}:${PW_PLUGINS_PATH}/portable/lib/lib64:${PW_PLUGINS_PATH}/portable/lib/lib32"
         [[ -d "${HOME}/.local/share/Steam/ubuntu12_32" ]] && steamplay_ld_library_path="${steamplay_ld_library_path}:${HOME}/.local/share/Steam/ubuntu12_32"
@@ -4914,9 +4974,74 @@ steamplay_launch () {
             unset MANGOHUD_CONFIG
         fi
 
+        if [[ $PW_GPU_USE != "disabled" ]] ; then
+            export DXVK_FILTER_DEVICE_NAME="$PW_GPU_USE"
+            export VKD3D_FILTER_DEVICE_NAME="$PW_GPU_USE"
+            if [[ -n "${PW_vendorID:-}" ]] && [[ -n "${PW_deviceID:-}" ]] ; then
+                export MESA_VK_DEVICE_SELECT_FORCE_DEFAULT_DEVICE="1"
+                export MESA_VK_DEVICE_SELECT="$PW_vendorID:$PW_deviceID"
+            else
+                unset MESA_VK_DEVICE_SELECT_FORCE_DEFAULT_DEVICE MESA_VK_DEVICE_SELECT
+            fi
+        else
+            unset DXVK_FILTER_DEVICE_NAME VKD3D_FILTER_DEVICE_NAME
+            unset MESA_VK_DEVICE_SELECT_FORCE_DEFAULT_DEVICE MESA_VK_DEVICE_SELECT
+        fi
+
+        if [[ -f "$PATH_TO_GAME/dxvk.conf" ]] ; then
+            export DXVK_CONFIG_FILE="$PATH_TO_GAME/dxvk.conf"
+            print_info "Custom dxvk.conf in use: $DXVK_CONFIG_FILE"
+        else
+            unset DXVK_CONFIG_FILE
+        fi
+
+        [[ "${PW_VKBASALT_USER_CONF}" == 1 ]] && unset PW_VKBASALT_EFFECTS PW_VKBASALT_FFX_CAS
+
         pw_optiscaler_sync_files
 
         PORT_WINE_PREFIX="$STEAM_COMPAT_DATA_PATH/pfx"
+        export WINEPREFIX="${PORT_WINE_PREFIX}"
+        create_new_dir "${WINEPREFIX}/drive_c/windows/system32"
+        create_new_dir "${WINEPREFIX}/drive_c/windows/syswow64"
+
+        if [[ "$PW_USE_OBS_VKCAPTURE" == "1" ]] ; then
+            export OBS_VKCAPTURE="1"
+            export PW_USE_SYSTEM_VK_LAYERS="1"
+            print_warning "System mangohud, vkBasalt, obs-vk capture and other applications using vulkan layers are forcibly used."
+        fi
+        if [[ "${PW_USE_NVAPI_AND_DLSS}" == "1" ]] ; then
+            export PROTON_FORCE_NVAPI="1"
+        else
+            unset PROTON_FORCE_NVAPI
+        fi
+        if [[ "${PW_USE_EAC_AND_BE}" == 1 ]] ; then
+            export PROTON_BATTLEYE_RUNTIME="${PW_PLUGINS_PATH}/BattlEye_Runtime"
+            export PROTON_EAC_RUNTIME="${PW_PLUGINS_PATH}/EasyAntiCheat_Runtime"
+            var_winedlloverride_update "beclient,beclient_x64=b,n"
+        else
+            unset PROTON_BATTLEYE_RUNTIME PROTON_EAC_RUNTIME
+        fi
+        if [[ "${PW_USE_WINE_DXGI}" == "1" ]] ; then
+            var_winedlloverride_update "dxgi=b"
+        fi
+        if [[ -n "${PW_RUN_AFTER_EXE:-}" ]] \
+        && [[ -f "${PW_RUN_AFTER_EXE}" ]] \
+        && [[ "${PW_RUN_AFTER_EXE}" != "${portwine_exe}" ]] \
+        && [[ "${portwine_exe,,}" =~ \.exe$ ]]
+        then
+            printf -v PROTON_REMOTE_DEBUG_CMD '%q' "${PW_RUN_AFTER_EXE}"
+            export PROTON_REMOTE_DEBUG_CMD
+            export PRESSURE_VESSEL_FILESYSTEMS_RW="${PRESSURE_VESSEL_FILESYSTEMS_RW:+$PRESSURE_VESSEL_FILESYSTEMS_RW:}$(dirname "${PW_RUN_AFTER_EXE}")"
+            print_info "PROTON_REMOTE_DEBUG_CMD=${PROTON_REMOTE_DEBUG_CMD}"
+        else
+            unset PROTON_REMOTE_DEBUG_CMD
+        fi
+        pw_apply_wined3d_settings
+        pw_apply_ray_tracing_and_nvapi_settings
+        pw_apply_graphics_env_tweaks
+        pw_apply_us_layout_settings
+        pw_apply_steamplay_shader_cache_settings
+        pw_apply_wayland_settings
 
         pw_prepare_gamescope_launch
 
@@ -4964,11 +5089,45 @@ steamplay_launch () {
         fi
 
         [[ $PW_LOG != 1 ]] && debug_timer --start -s "PW_TIME_IN_GAME"
+
         if [[ -x "${STEAM_COMPAT_TOOL_PATHS%%:*}/proton" ]] ; then
             proton_runner="${STEAM_COMPAT_TOOL_PATHS%%:*}/proton"
         elif [[ -x "${PORT_WINE_PATH}/data/dist/${PW_WINE_USE}/proton" ]] ; then
             proton_runner="${PORT_WINE_PATH}/data/dist/${PW_WINE_USE}/proton"
+        else
+            fatal "proton runner not found"
         fi
+
+        if [[ ! -f "${WINEPREFIX}/system.reg" ]] \
+        || ! grep -iq "Microsoft Windows $PW_WINDOWS_VER" "${WINEPREFIX}/system.reg"
+        then
+            if [[ -n $PW_WINDOWS_VER ]] \
+            && [[ $(echo "$PW_WINDOWS_VER" | sed 's/.*/\L&/') == "xp" ]]
+            then
+                export PW_WINDOWS_VER="xp64"
+            fi
+            "${proton_runner}" run winecfg -v "$(echo "win${PW_WINDOWS_VER}" | sed 's/.*/\L&/')" &>/dev/null
+            print_info "Steam Play set to win${PW_WINDOWS_VER}"
+        fi
+
+        [[ $PW_DINPUT_PROTOCOL == "1" ]] && unset PROTON_PREFER_SDL || export PROTON_PREFER_SDL="1"
+        if [[ -n "${WINE_WAYLAND_HACKS:-}" ]] ; then
+            export PROTON_ENABLE_WAYLAND="1"
+        else
+            unset PROTON_ENABLE_WAYLAND
+        fi
+        if [[ "${DXVK_HDR:-}" == "1" ]] ; then
+            export PROTON_ENABLE_HDR="1"
+        else
+            unset PROTON_ENABLE_HDR
+        fi
+
+        case "$PW_SOUND_DRIVER_USE" in
+            pulse) "${proton_runner}" run reg add "HKEY_CURRENT_USER\\Software\\Wine\\Drivers" /v "Audio" /t "REG_SZ" /d "pulse" /f &>/dev/null ;;
+            alsa) "${proton_runner}" run reg add "HKEY_CURRENT_USER\\Software\\Wine\\Drivers" /v "Audio" /t "REG_SZ" /d "alsa" /f &>/dev/null ;;
+            oss) "${proton_runner}" run reg add "HKEY_CURRENT_USER\\Software\\Wine\\Drivers" /v "Audio" /t "REG_SZ" /d "oss" /f &>/dev/null ;;
+            *) "${proton_runner}" run reg delete "HKEY_CURRENT_USER\\Software\\Wine\\Drivers" /v "Audio" /f &>/dev/null ;;
+        esac
 
         # Virtual Desktop
         if [[ "${PW_VIRTUAL_DESKTOP}" == "1" ]] ; then
@@ -4987,6 +5146,15 @@ steamplay_launch () {
             print_info "Steam Play virtual desktop disabled in registry"
         fi
 
+        if [[ -n "${LAUNCH_OPTIONS:-}" ]] ; then
+            while IFS= read -r launch_option ; do
+                steamplay_launch_options+=("${launch_option}")
+            done < <(xargs -n1 printf '%s\n' <<< "${LAUNCH_OPTIONS}")
+            print_info "Steam Play LAUNCH_OPTIONS: ${LAUNCH_OPTIONS}"
+        fi
+
+        pw_toggle_compositing disable
+
         ${PW_RUN_GAMESCOPE} \
         env \
         LD_LIBRARY_PATH="${steamplay_ld_library_path}" \
@@ -4995,7 +5163,15 @@ steamplay_launch () {
         ${PW_GAMEMODERUN_SLR} \
         ${PW_INHIBIT_SLR} \
         ${PW_TASKSET_SLR} \
-        "${proton_runner}" waitforexitandrun "${portwine_exe}" "$@"
+        "${proton_runner}" waitforexitandrun "${portwine_exe}" \
+        "${steamplay_launch_options[@]}" "$@"
+        if [[ "$PW_USE_US_LAYOUT" == "1" ]] \
+        && ! check_wayland_session \
+        && command -v setxkbmap &>/dev/null
+        then
+            setxkbmap
+        fi
+        pw_toggle_compositing restore
         stop_activity_simulation
         if [[ $PW_LOG != 1 ]] && [[ -n $START_PW_TIME_IN_GAME ]] ; then
             debug_timer --end -s "PW_TIME_IN_GAME"


### PR DESCRIPTION
## Не рабочее
   - PW_USE_GSTREAMER (У Proton свой Gstreamer, от PP не нужен, когда включать отключать так же разберутся protonfixes)
   - PW_USE_VRCLIENT (Нет в интерфейсе да и похоже Proton сам копирует свой vrclient)
   - PW_USE_D3D_EXTRAS (Proton всегда копирует d3d библиотеки от себя, поэтому эта функция по сути всегда включена)
   - PW_USE_DGVOODOO2 (Нет в PPQT, добавлю потом)
   - PW_PREFIX_NAME (Proton ожидает именно pfx иначе часть кода ломается)
   - PW_VULKAN_USE (Proton всегда принудительно копирует dxvk из себя, не придумал как это обойти)
   - PW_WINE_ALLOW_XIM (Нет в интерфейсе)
   - PW_USE_SUPPLIED_DXVK_VKD3D (по сути всегда включено)
   - PW_USE_SAREK_ASYNC (Раз уж Sarek нельзя выбрать нет смысла его чинить)
  

Ещё DXVK_STATE_CACHE="disabled" заменён на 0, disabled он не понимает