### PR TITLE
Fix Steam Deck DXVK GPU filter

### DIFF
--- a/data_from_portwine/scripts/functions_helper
+++ b/data_from_portwine/scripts/functions_helper
@@ -3892,8 +3892,12 @@ start_portwine () {
     [[ "${PW_VKBASALT_USER_CONF}" == 1 ]] && unset PW_VKBASALT_EFFECTS PW_VKBASALT_FFX_CAS
 
     if [[ $PW_GPU_USE != "disabled" ]] ; then
-        export DXVK_FILTER_DEVICE_NAME="$PW_GPU_USE"
-        export VKD3D_FILTER_DEVICE_NAME="$PW_GPU_USE"
+        PW_GPU_FILTER_NAME="$PW_GPU_USE"
+        if [[ "$PW_GPU_FILTER_NAME" == "AMD Custom GPU 0405 (RADV VANGOGH)" ]] ; then
+            PW_GPU_FILTER_NAME="AMD VANGOGH"
+        fi
+        export DXVK_FILTER_DEVICE_NAME="$PW_GPU_FILTER_NAME"
+        export VKD3D_FILTER_DEVICE_NAME="$PW_GPU_FILTER_NAME"
         export MESA_VK_DEVICE_SELECT_FORCE_DEFAULT_DEVICE="1"
         export MESA_VK_DEVICE_SELECT="$PW_vendorID:$PW_deviceID"
     fi
@@ -8302,4 +8306,3 @@ find_ext_ppdb () {
         restart_pp
     fi
 }
-


### PR DESCRIPTION
## Summary

Fix Steam Deck GPU filtering for DXVK/VKD3D by mapping PortProton's detected GPU name to the device name DXVK actually reports.

On Steam Deck, `PW_GPU_USE` can be saved as:

```bash
AMD Custom GPU 0405 (RADV VANGOGH)
```

DXVK reports the Vulkan device as:

```text
AMD VANGOGH
```

Passing `PW_GPU_USE` directly to `DXVK_FILTER_DEVICE_NAME` filters out the only GPU and causes `DXVK: No adapters found`.

## Fix

Keep `PW_GPU_USE` unchanged for PortProton UI/device selection, but use a normalized value for:

```bash
DXVK_FILTER_DEVICE_NAME
VKD3D_FILTER_DEVICE_NAME
```

## Verification

Tested on Steam Deck with Vampyr (D3D11/UE4):

Before:

```text
Found device: AMD VANGOGH (radv 26.0.8)
Skipping: Device filter
DXVK: No adapters found
Failed to initialize DXVK.
```

After:

```text
Found device: AMD VANGOGH (radv 26.0.8)
D3D11InternalCreateDevice: Maximum supported feature level: D3D_FEATURE_LEVEL_12_1
D3D11InternalCreateDevice: Using feature level D3D_FEATURE_LEVEL_11_0
```

Fixes #620
